### PR TITLE
Downgrade sass to resolve deprecation warnings

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -36,7 +36,7 @@
     "prismjs": "^1.20.0",
     "reflect-metadata": "^0.1.13",
     "roboto-fontface": "*",
-    "sass": "^1.34.1",
+    "sass": "~1.32.1",
     "sass-loader": "^10.0.0",
     "ttypescript": "^1.5.10",
     "typescript": "~4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12536,10 +12536,10 @@ sass-loader@^10.0.0:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass@^1.34.1:
-  version "1.37.5"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.37.5.tgz#f6838351f7cc814c4fcfe1d9a20e0cabbd1e7b3c"
-  integrity sha512-Cx3ewxz9QB/ErnVIiWg2cH0kiYZ0FPvheDTVC6BsiEGBTZKKZJ1Gq5Kq6jy3PKtL6+EJ8NIoaBW/RSd2R6cZOA==
+sass@~1.32.1:
+  version "1.32.13"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.13.tgz#8d29c849e625a415bce71609c7cf95e15f74ed00"
+  integrity sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
Since sass version 1.33, the vuetify library spews out a ton of deprecation warnings. Currently their recommendation is to downgrade to sass 1.33 (https://github.com/vuetifyjs/vuetify/issues/13694#issuecomment-852957010).