### PR TITLE
Small tweaks to user interface, improving overall experience

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -40,7 +40,9 @@
       </v-navigation-drawer>
 
       <v-main>
-        <router-view />
+        <keep-alive exclude="Compare">
+          <router-view />
+        </keep-alive>
       </v-main>
     </v-app>
 </template>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -48,18 +48,24 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from "vue-property-decorator";
+import { Vue, Component } from "vue-property-decorator";
 
 @Component({})
 export default class App extends Vue {
-  @Prop() drawerEnabled = false;
+  drawerEnabled = false;
+
+  navigateTo(route: string): void {
+    if (this.$router.currentRoute.path !== route) {
+      this.$router.push(route);
+    }
+  }
 
   toHomeScreen(): void {
-    this.$router.push("/");
+    this.navigateTo("/");
   }
 
   toGraphView(): void {
-    this.$router.push("/graph/");
+    this.navigateTo("/graph/");
   }
 }
 </script>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -7,13 +7,17 @@
         dark
         dense
       >
+        <v-app-bar-nav-icon
+            v-if="$vuetify.breakpoint.mobile"
+            @click.stop="drawerEnabled = !drawerEnabled"></v-app-bar-nav-icon>
         <v-toolbar-title @click="toHomeScreen">DOLOS</v-toolbar-title>
       </v-app-bar>
 
       <v-navigation-drawer
+          v-model="drawerEnabled"
           clipped
           app
-          expand-on-hover
+          :expand-on-hover="!$vuetify.breakpoint.mobile"
       >
         <v-list nav>
           <v-list-item @click="toHomeScreen" link>
@@ -42,10 +46,12 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component } from "vue-property-decorator";
+import { Vue, Component, Prop } from "vue-property-decorator";
 
 @Component({})
 export default class App extends Vue {
+  @Prop() drawerEnabled = false;
+
   toHomeScreen(): void {
     this.$router.push("/");
   }

--- a/web/src/api/api.ts
+++ b/web/src/api/api.ts
@@ -198,7 +198,7 @@ function parseMetadata(data: d3.DSVRowArray): Metadata {
   );
 }
 
-export async function populateFragments(pair: Pair, kmers: ObjMap<Kgram>): Promise<void> {
+export async function loadFragments(pair: Pair, kmers: ObjMap<Kgram>): Promise<void> {
   const fragments = fetchFragments(pair.id);
   pair.fragments = parseFragments(await fragments, kmers);
 }

--- a/web/src/components/CompareCard.vue
+++ b/web/src/components/CompareCard.vue
@@ -71,6 +71,7 @@
                             :identifier="SideID.leftSideId"
                             :selected-selections="selected.sides.leftSideId.fragmentClasses"
                             :selections="leftSelections"
+                            :language="language"
                             @codescroll="onScrollHandler"
                             @linesvisibleamount="setLinesVisible"
                             @selectionclick="selectionClickEventHandler"
@@ -108,6 +109,7 @@
                             :identifier="SideID.rightSideId"
                             :selected-selections="selected.sides.rightSideId.fragmentClasses"
                             :selections="rightSelections"
+                            :language="language"
                             @codescroll="onScrollHandler"
                             @selectionclick="selectionClickEventHandler"
                             @selectionhoverenter="onHoverEnterHandler"
@@ -188,7 +190,7 @@
 </template>
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from "vue-property-decorator";
-import { Fragment, Pair, Selection } from "@/api/api";
+import { Fragment, Metadata, Pair, Selection } from "@/api/api";
 import CompareSide from "@/components/CompareSide.vue";
 import BarcodeChart from "@/components/BarcodeChart.vue";
 import { constructID, SelectionId } from "@/util/OccurenceHighlight";
@@ -221,7 +223,7 @@ export enum SideID {
 export default class CompareCard extends Vue {
   @Prop({ default: false, required: true }) loaded!: boolean;
   @Prop({ required: true }) pair!: Pair;
-  @Prop({ required: true }) kgramLength!: number;
+  @Prop({ required: true }) metadata!: Metadata;
 
   shortcutsHelptext = [
     ["Left Arrow", "Previous"],
@@ -277,6 +279,14 @@ export default class CompareCard extends Vue {
   leftScrollFraction = 0;
   rightScrollFraction = 0;
   linesVisible = 0;
+
+  get language(): string {
+    return this.metadata.language as string;
+  }
+
+  get kgramLength(): number {
+    return this.metadata.kgramLength as number;
+  }
 
   get activePair() : Pair {
     if (this.filesSwapped) {

--- a/web/src/components/CompareSide.vue
+++ b/web/src/components/CompareSide.vue
@@ -41,6 +41,7 @@ import { ID_START, registerFragmentHighlighting } from "@/util/OccurenceHighligh
 export default class CompareSide extends Vue {
   @Prop({ required: true }) identifier!: string;
   @Prop({ required: true }) file!: File;
+  @Prop({ required: true }) language!: string;
   @Prop({ required: true }) selections!: Array<Selection>;
   @Prop({ required: true }) hoveringSelections!: Array<string>;
   @Prop({ required: true }) activeSelections!: Array<string>;
@@ -48,10 +49,6 @@ export default class CompareSide extends Vue {
 
   get content(): string {
     return this.file.content;
-  }
-
-  get language(): string {
-    return this.$store.state.data.metadata.language;
   }
 
   onScroll(e: Event): void {

--- a/web/src/store/api.ts
+++ b/web/src/store/api.ts
@@ -1,0 +1,67 @@
+import {
+  ApiData,
+  fetchData,
+  File,
+  Kgram,
+  Metadata,
+  ObjMap,
+  Pair,
+  loadFragments
+} from "@/api/api";
+import Vue from "vue";
+import { ActionContext } from "vuex";
+
+interface State {
+  kgrams: ObjMap<Kgram>;
+  files: ObjMap<File>;
+  pairs: ObjMap<Pair>;
+  metadata: Metadata;
+  isLoaded: boolean;
+}
+
+type Context = ActionContext<State, Record<string, never>>;
+
+export default {
+  state: (): State => ({
+    kgrams: {},
+    files: {},
+    pairs: {},
+    metadata: {},
+    isLoaded: false,
+  }),
+  getters: {
+    areFragmentsLoaded(state: State): (n: number) => boolean {
+      return n => state.pairs[n]?.fragments != null;
+    },
+    pair(state: State): (n: number) => Pair {
+      return n => state.pairs[n];
+    }
+  },
+  mutations: {
+    setData(state: State, data: ApiData): void {
+      state.kgrams = data.kgrams;
+      state.files = data.files;
+      state.pairs = data.pairs;
+      state.metadata = data.metadata;
+      state.isLoaded = true;
+    },
+    updatePair(state: State, pair: Pair): void {
+      Vue.set(state.pairs, pair.id, pair);
+    }
+  },
+  actions: {
+    async loadData({ commit }: Context): Promise<void> {
+      const data = await fetchData();
+      commit("setData", data);
+    },
+    async populateFragments(
+      { commit, getters, state }: Context,
+      data: { pairId: number}
+    ): Promise<void> {
+      const pair = getters.pair(data.pairId);
+      const kgrams = state.kgrams;
+      await loadFragments(pair, kgrams);
+      commit("updatePair", pair);
+    }
+  }
+};

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -1,48 +1,15 @@
 import Vue from "vue";
 import Vuex from "vuex";
-import { ApiData, fetchData, Pair, Kgram, Metadata, File, ObjMap, populateFragments } from "@/api/api";
+import Api from "@/store/api";
 
 Vue.use(Vuex);
 
 export default new Vuex.Store({
-  state: {
-    dataLoaded: false,
-    data: {
-      kgrams: Object() as ObjMap<Kgram>,
-      files: Object() as ObjMap<File>,
-      pairs: Object() as ObjMap<Pair>,
-      metadata: Object() as Metadata,
-    }
-  },
-  getters: {
-    areFragmentsLoaded: state => (diffId: number) => {
-      return !!state.data.pairs[diffId] && !!state.data.pairs[diffId].fragments;
-    },
-    kgrams: state => state.data.kgrams,
-    pair: state => (pairId: number) => {
-      return state.data.pairs[pairId];
-    }
-  },
-  mutations: {
-    setData(state, data: ApiData) {
-      state.dataLoaded = true;
-      state.data = data;
-    },
-    updatePair(state, data: { pair: Pair }) {
-      Vue.set(state.data.pairs, data.pair.id, data.pair);
-    }
-  },
-  actions: {
-    loadData({ commit }): Promise<void> {
-      return fetchData().then(data => commit("setData", data));
-    },
-    populateFragments({ commit, getters }, data: { pairId: number }): Promise<void> {
-      const diff = getters.pair(data.pairId);
-      return populateFragments(diff, getters.kgrams)
-        .then(() => commit("updatePair", { pair: diff }));
-    }
-  },
+  state: {},
+  getters: {},
+  mutations: {},
+  actions: {},
   modules: {
-
+    api: Api
   }
 });

--- a/web/src/views/Compare.vue
+++ b/web/src/views/Compare.vue
@@ -6,7 +6,7 @@
           v-if="pair && pair.fragments"
           :loaded="dataLoaded"
           :pair="pair"
-          :kgram-length="kgramLength"
+          :metadata="metadata"
         />
         <v-card v-else>
           <v-card-subtitle>
@@ -31,7 +31,7 @@ export default class Compare extends DataView {
   @Prop({ required: true }) pairId!: number;
 
   async ensureFragments(): Promise<void> {
-    if (!this.$store.getters.areFragmentsLoaded(this.pairId)) {
+    if (!this.dataLoaded) {
       await this.$store.dispatch("populateFragments", { pairId: this.pairId });
     }
   }
@@ -47,10 +47,6 @@ export default class Compare extends DataView {
 
   get pair(): Pair | undefined {
     return this.pairs[+this.pairId];
-  }
-
-  get kgramLength(): number {
-    return this.metadata.kgramLength as number;
   }
 
   get dataLoaded(): boolean {

--- a/web/src/views/DataView.ts
+++ b/web/src/views/DataView.ts
@@ -1,26 +1,26 @@
-import { Pair, ObjMap, Metadata } from "@/api/api";
+import { Pair, ObjMap, Metadata, File } from "@/api/api";
 import { Vue } from "vue-property-decorator";
 
 export default abstract class DataView extends Vue {
   async ensureData(): Promise<void> {
-    if (!this.$store.state.dataLoaded) {
+    if (!this.$store.state.api.isLoaded) {
       await this.$store.dispatch("loadData");
     }
   }
 
   get metadata(): Metadata {
-    return this.$store.state.data.metadata;
+    return this.$store.state.api.metadata;
   }
 
   get pairs(): ObjMap<Pair> {
-    return this.$store.state.data.pairs;
+    return this.$store.state.api.pairs;
   }
 
   get files(): ObjMap<File> {
-    return this.$store.state.data.files;
+    return this.$store.state.api.files;
   }
 
   get dataLoaded(): boolean {
-    return this.$store.state.dataLoaded;
+    return this.$store.state.api.isLoaded;
   }
 }


### PR DESCRIPTION
Visible:
- [x] Remember state of main pages (plagiarism graph and pairs table) when navigating through results
- [x] Show a navigation drawer icon on mobile


Under the hood:
- [x] Make better use of the `vuex` store by splitting the state into a module
- [x] Resolve some warnings printed to the console