### PR TITLE
Fix dependabot not updating yarn.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,24 +7,6 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
 - package-ecosystem: npm
-  directory: "/web"
-  schedule:
-    interval: weekly
-    time: "13:00"
-    timezone: Europe/Brussels
-- package-ecosystem: npm
-  directory: "/cli"
-  schedule:
-    interval: weekly
-    time: "13:00"
-    timezone: Europe/Brussels
-- package-ecosystem: npm
-  directory: "/docs"
-  schedule:
-    interval: weekly
-    time: "13:00"
-    timezone: Europe/Brussels
-- package-ecosystem: npm
   directory: "/"
   schedule:
     interval: weekly


### PR DESCRIPTION
Dependabot should be able to work with yarn workspaces where we have a single `yarn.lock` file in our repository root.

Depenabot is currently only updating only the `package.json` files, I am assuming these are the separate directories themselves, which are now removed with this PR.