### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -6,8 +6,8 @@ parser library, to support a broad range of programming languages.
 
 
 - [Try Dolos](/try/)
-- [Install Dolos](/guide/installation)
-- [How to use Dolos](/guide/running)
+- [Install Dolos](/guide/installation.html)
+- [How to use Dolos](/guide/running.html)
 
 
 ## What's in a name?

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -72,7 +72,7 @@ dolos --version
 
 Dolos already supports most common programming languages out-of-the box.
 However, if the language you want to use is not supported, you can easily
-[add a new language](/guide/languages#adding-a-new-language).
+[add a new language](/guide/languages.html#adding-a-new-language).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Some links in the documentation were broken, because the vuepress development server translates links like `/guide/installation` to `/guide/installation.html`, but the production server does not have this behavior.