### PR TITLE
Fix navigation drawer being hidden on desktop

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -52,7 +52,11 @@ import { Vue, Component } from "vue-property-decorator";
 
 @Component({})
 export default class App extends Vue {
-  drawerEnabled = false;
+  drawerEnabled = true;
+
+  created(): void {
+    this.drawerEnabled = !this.$vuetify.breakpoint.mobile;
+  }
 
   navigateTo(route: string): void {
     if (this.$router.currentRoute.path !== route) {


### PR DESCRIPTION
The navigation drawer was hidden on larger resolutions because the default of `drawerEnabled` was set to `false.
This intializes `drawerEnabled` with `true` on large resolutions and `false` when on small (mobile) resolutions.