### PR TITLE
fixed cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           path: |
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/*/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock', '/package.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock') }}-${{ hashFiles('/package.json') }}
       - name: Setup Node
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         uses: actions/setup-node@v2
@@ -49,7 +49,7 @@ jobs:
           path: |
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/*/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock', '/package.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock') }}-${{ hashFiles('/package.json') }}
       - name: Check if cache was hit
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
@@ -98,7 +98,7 @@ jobs:
           path: |
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/*/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock', '/package.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock') }}-${{ hashFiles('/package.json') }}
       - name: Check if cache was hit
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
@@ -130,7 +130,7 @@ jobs:
           path: |
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/*/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock', '/package.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock') }}-${{ hashFiles('/package.json') }}
       - name: Check if cache was hit
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
@@ -163,7 +163,7 @@ jobs:
           path: |
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/*/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock', '/package.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock') }}-${{ hashFiles('/package.json') }}
       - name: Check if cache was hit
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
@@ -195,7 +195,7 @@ jobs:
           path: |
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/*/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock', '/package.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock') }}-${{ hashFiles('/package.json') }}
       - name: Check if cache was hit
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
@@ -228,7 +228,7 @@ jobs:
           path: |
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/*/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock', '/package.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock') }}-${{ hashFiles('/package.json') }}
       - name: Check if cache was hit
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
@@ -260,7 +260,7 @@ jobs:
           path: |
             ${{ github.workspace }}/node_modules
             ${{ github.workspace }}/*/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock', '/package.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('/yarn.lock') }}-${{ hashFiles('/package.json') }}
       - name: Check if cache was hit
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
according to the documentation the `hashFiles` function accepts multiple files, however in practice it returns an empty string when given multiple arguments. This fix circumvents that.