### PR TITLE
feat(host): added new option to define a host

### DIFF
--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -99,6 +99,14 @@ export function runCommand(program: Command): Command {
       "3000"
     )
     .option(
+      "-H, --host <host>",
+      Utils.indent(
+        "Specifies on which host --output-format=web should be served.",
+        "localhost"
+      ),
+      "localhost"
+    )
+    .option(
       "-o, --output-destination <path>",
       Utils.indent(
         "Path where to write the output report to. " +
@@ -153,6 +161,7 @@ interface RunOptions extends Options {
   compare: boolean;
   open: boolean;
   port: number;
+  host: string;
   outputFormat: string;
   outputDestination: string;
 }

--- a/cli/src/cli/commands/serve.ts
+++ b/cli/src/cli/commands/serve.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { promises as fs, constants } from "fs";
 import * as path from "path";
-import runServer, { DEFAULT_PORT } from "../server";
+import runServer, { DEFAULT_HOST, DEFAULT_PORT } from "../server";
 import * as Utils from "../../lib/util/utils";
 import { tryCatch, error, setLogging } from "../../lib/util/utils";
 
@@ -23,12 +23,21 @@ export function serveCommand(program: Command): Command {
       x => parseInt(x),
       DEFAULT_PORT
     )
+    .option(
+      "-H --host <host>",
+      Utils.indent(
+        "HOST to serve the webserver on."
+      ),
+      x => x,
+      DEFAULT_HOST
+    )
     .action((reportDir, options) => serve(reportDir, { ...options, ...program.opts() }));
 }
 
 interface ServeOptions {
   open: boolean;
   port: number;
+  host: string;
   verbose: boolean;
 }
 

--- a/cli/src/cli/server.ts
+++ b/cli/src/cli/server.ts
@@ -18,9 +18,11 @@ function assets(): string {
 }
 
 export const DEFAULT_PORT = 3000;
+export const DEFAULT_HOST = "localhost";
 
 export interface Options {
   port?: number;
+  host?: string;
   open?: boolean;
 }
 
@@ -29,6 +31,7 @@ export default async function runServer(
   options: Options
 ): Promise<void> {
   const port = options.port || DEFAULT_PORT;
+  const host = options.host || DEFAULT_HOST;
   const openInBrowser = options.open == undefined ? true : options.open;
 
   const app: Express = express();
@@ -45,9 +48,9 @@ export default async function runServer(
     server.on("error", e);
   });
 
-  server.listen(port, "localhost");
+  server.listen(port, host);
 
-  const url = `http://localhost:${ port }`;
+  const url = `http://${ host }:${ port }`;
 
   await serverStarted;
   console.log(`Dolos is available on ${ url }`);

--- a/server/src/config/environment.d.ts
+++ b/server/src/config/environment.d.ts
@@ -1,4 +1,5 @@
 export interface Environment {
   port: number;
+  host: string;
   baseURI: string;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,7 +8,7 @@ import { router } from "./routes";
 const env = getConfig();
 const app: Express = express();
 const port = env.port;
-
+const host = env.host;
 
 app.engine("eta", Eta.renderFile);
 app.set("view engine", "eta");
@@ -32,5 +32,5 @@ app.use(env.baseURI, router);
 
 
 app.listen(port, () => {
-  console.log(`Dolos-server is listening on http://localhost:${port}`);
+  console.log(`Dolos-server is listening on http://${host}:${port}`);
 });


### PR DESCRIPTION
This pull request adding a new option to define a host. Previously default host is localhost which is problematic when you want work with docker container and don't want to use a host network.