### PR TITLE
Add explanation of the analysis parameters

### DIFF
--- a/docs/guide/algorithm.md
+++ b/docs/guide/algorithm.md
@@ -44,14 +44,17 @@ Next, we can start looking for similarities in the submitted files.
 ## Fingerprinting
 
 To measure similarities between (converted) files, Dolos tries to find common
-substrings between them. We use substrings of a fixed length called k-grams.
-To efficiently make these comparisons and reduce the memory usage, all k-grams
+substrings between them. We use substrings of a fixed length called _k_-grams.
+To efficiently make these comparisons and reduce the memory usage, all _k_-grams
 are hashed using a rolling hash function (the one used by Rabin-Karp in their
-string matching algorithm).
+string matching algorithm). The length _k_ of _k_-grams can be with the `-k`
+option.
 
 To further reduce the memory usage, only a subset of all hashes are stored. The
 selection of which hashes to store is done by the Winnowing algorithm as
-described by [(Schleimer, Wilkerson and Aiken)](http://theory.stanford.edu/~aiken/publications/papers/sigmod03.pdf).
+described by [(Schleimer, Wilkerson and Aiken)](http://theory.stanford.edu/~aiken/publications/papers/sigmod03.pdf). In short: only the hash with the smallest numerical
+value is kept for each window. The window length (in _k_-grams) can be altered
+with the `-w` option.
 
 The remaining hashes are the **fingerprints** of the analyzed files. Internally,
 these are stored as simple integers.

--- a/docs/guide/running.md
+++ b/docs/guide/running.md
@@ -42,11 +42,11 @@ The analysis parameters can be altered by passing the relevant program
 arguments. For more information about the impact of these parameters you can
 read the section describing [how Dolos works](./algorithm.html).
 
-If you are having performance issues with Dolos, it can help to alter these
-parameters. It is recommended to increase the Window length (`-w`) first before
-altering the _k_-gram length (`-k`).
+If a Dolos analysis is taking too long or consuming too much memory, it can
+help to alter these parameters. It is recommended to increase the Window length
+(`-w`) first before altering the _k_-gram length (`-k`).
 
-### Kgram length
+### _k_-gram length
 
 Short: `-k <integer>`, long: `--kgram-length <integer>`, default: `23`.
 

--- a/docs/guide/running.md
+++ b/docs/guide/running.md
@@ -36,6 +36,45 @@ You can show all the command-line options by passing the `-h` or `--help` flag
 or by running `dolos help run`.
 :::
 
+## Modifying analysis parameters
+
+The analysis parameters can be altered by passing the relevant program
+arguments. For more information about the impact of these parameters you can
+read the section describing [how Dolos works](./algorithm.html).
+
+If you are having performance issues with Dolos, it can help to alter these
+parameters. It is recommended to increase the Window length (`-w`) first before
+altering the _k_-gram length (`-k`).
+
+### Kgram length
+
+Short: `-k <integer>`, long: `--kgram-length <integer>`, default: `23`.
+
+This changes the number of of _tokens_ contained in a single _k_-gram. This is the
+minimum matchable unit: corresponding fragments in two files smaller than this
+value will not be found.
+
+Larger values decrease memory usage and decrease running time, but will result
+in fewer detections.
+
+### Window length
+
+Short: `-w <integer>`, long: `--kgrams-in-window <integer>`, default: `17`.
+
+This changes window length (in _k_-grams) used by the Winnowing algorithm. The
+algorithm will pick one out of every `w` subsequent _k_-grams. This will
+therefore reduce memory usage `w` times.
+
+Larger values decrease memory usage and decrease running time, but will result
+in fewer detections.
+
+### Other parameters
+
+Dolos includes other parameters that can be used to finetune the analysis. A
+more detailed listing of these parameters and their function can be viewed by
+running `dolos --help`.
+
+
 ## Output format
 
 You can specify how Dolos reports its results by setting the `-f` or `--output-format` flag.


### PR DESCRIPTION
This PR adds a section to the documentation to explain the function and impact of the `-k` and `-w` parameters.

The other parameters are intentionally omitted because these parameters can change in the future. Instead, I refer to the output of `dolos --help`.

If we want a complete overview of the command-line options on the documentation site, this could be generated using the code in [run.ts](https://github.com/dodona-edu/dolos/blob/main/cli/src/cli/commands/run.ts) and [options.ts](https://github.com/dodona-edu/dolos/blob/main/lib/src/lib/util/options.ts). But this will be a lot of work for something that is already available.