### PR TITLE
Add a README to dolos-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Dolos aims to be:
 Dolos is a command-line (CLI) tool that analyses source code files for similarities between them.
 It is able to show an interactive user interface in your browser by launching a local webserver.
 The analysis results are available in machine readable CSV files and Dolos can be integrated as a
-[JavaScript library](https://www.npmjs.com/package/@dodona/dolos) in other applications empowering
+[JavaScript library](https://www.npmjs.com/package/@dodona/dolos-lib) in other applications empowering
 users to integrate plagiarism detection in their personal workflow.
 
 ## Installation
@@ -51,7 +51,7 @@ show the results in your browser.
 
 Launch Dolos using the following command in your terminal:
 ```shell
-dolos -f web --language <language> path/to/your/files/*
+dolos run -f web --language <language> path/to/your/files/*
 ```
 The above command will launch a web interface with the analysis results at <http://localhost:3000>.
 
@@ -73,15 +73,18 @@ running `yarn install`. This will install all dependencies and link them in each
 project's `node_modules`. You should **not** run `yarn install` in each
 project's directory separately.
 
-This will also link the `dist` folder from the web project as `dolos-web` in the
-CLI project as long as the `cli/package.json` mentions `dolos-web` with the
-correct version as a dependency. This allows you to simultaneously develop the
-CLI and the Web project together.
+This will also link the `dist` folder from the web and lib projects as
+`dolos-web` and `dolos-lib` in the CLI project as long as the
+`cli/package.json` mentions `@dodona/dolos-web` and `@dodona/dolos-lib` with
+the correct version as a dependency. This allows you to simultaneously develop
+the CLI, lib and the web project together.
 
 Each project has its own build instructions in its own directory.
 
 ## Projects
 
-- [CLI](https://github.com/dodona-edu/dolos/tree/main/cli): the core library and command-line interface
+- [CLI](https://github.com/dodona-edu/dolos/tree/main/cli): the command-line interface
+- [Lib](https://github.com/dodona-edu/dolos/tree/main/lib): the core library
 - [Web](https://github.com/dodona-edu/dolos/tree/main/web): the graphical user interface in your browser which can be launched using the CLI
 - [Docs](https://github.com/dodona-edu/dolos/tree/main/docs): the source code of <https://dolos.ugent.be>
+- [Server](https://github.com/dodona-edu/dolos/tree/main/server): (experimental) a webserver exposing Dolos as a web application

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,7 +32,7 @@ Dolos aims to be:
 Dolos is a command-line (CLI) tool that analyses source code files for similarities between them.
 It is able to show an interactive user interface in your browser by launching a local webserver.
 The analysis results are available in machine readable CSV files and Dolos can be integrated as a
-[JavaScript library](https://www.npmjs.com/package/@dodona/dolos) in other applications empowering
+[JavaScript library](https://www.npmjs.com/package/@dodona/dolos-lib) in other applications empowering
 users to integrate plagiarism detection in their personal workflow.
 
 ## Installation

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,49 @@
+# Dolos lib
+
+This is the software library behind [Dolos](https://dolos.ugent.be). It exposes
+a JavaScript API to integrate plagiarism detection in your applications.
+
+Visit [dolos.ugent.be](https://dolos.ugent.be) for more information.
+
+## Installation
+
+```
+yarn add @dodona/dolos-lib # or,
+npm install @dodona/dolos-lib
+```
+
+### Node & Web environments
+
+Dolos uses [tree-sitter](https://www.npmjs.com/package/tree-sitter) to parse
+source code files. Tree-sitter currently only runs in node and will thus not
+run in browser environments. Since some of the library's functionality is use
+by the [Dolos Web UI](https://www.npmjs.com/package/@dodona/dolos-web), the
+dependency on tree-sitter is optional.
+
+## Usage
+
+```typescript
+import { Dolos } from "@dodona/dolos-lib";
+
+const dolos = new Dolos();
+const report = dolos.analyzePaths(["./file1.js", "./file2.js"]);
+```
+
+## Development
+
+1. Install dependencies (preferably in the repository root)
+    ```
+    yarn install
+    ```
+2. Build the project with typescript
+    ```
+    yarn build
+    ```
+3. Test the project with ava.js
+    ```
+    yarn test
+    ```
+
+## Documentation
+
+Visit our web page at <https://dolos.ugent.be>.


### PR DESCRIPTION
The dolos-lib project was missing a `README` file, resulting in an empty page on npmjs.

This PR adds a `README` with a usage and development instructions.