### PR TITLE
Fix: Non-hardcoded tokenizers supported

### DIFF
--- a/lib/src/dolos.ts
+++ b/lib/src/dolos.ts
@@ -16,11 +16,8 @@ function newTokenizer(language: string): Tokenizer {
   } else {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const CodeTokenizer = require("./lib/tokenizer/codeTokenizer").CodeTokenizer;
-    if (CodeTokenizer.supportedLanguages.includes(language)) {
-      return new CodeTokenizer(language);
-    }
+    return new CodeTokenizer(language);
   }
-  throw new Error(`No tokenizer found for ${language}`);
 }
 
 export class Dolos {


### PR DESCRIPTION
This PR enables the use of non-hardcoded tokenizers in the form of locally installed tree-sitter-x libraries.