### PR TITLE
fix 733: fragments folder check

### DIFF
--- a/cli/src/cli/commands/serve.ts
+++ b/cli/src/cli/commands/serve.ts
@@ -47,7 +47,7 @@ export async function serve(reportDir: string, options: ServeOptions): Promise<v
 
   tryCatch(options.verbose, async () => {
     try {
-      for (const file of ["files.csv", "kgrams.csv", "metadata.csv", "pairs.csv", "fragments"]) {
+      for (const file of ["files.csv", "kgrams.csv", "metadata.csv", "pairs.csv"]) {
         await fs.access(path.join(reportDir, file), constants.R_OK);
       }
     } catch (e) {


### PR DESCRIPTION
This PR removes a legacy check for the fragments folder, which is no longer in use since @ArneCJacobs added the dynamic caluclation a few months ago.