### PR TITLE
Update require for now scoped tree-sitter-elm package

### DIFF
--- a/lib/src/lib/tokenizer/codeTokenizer.ts
+++ b/lib/src/lib/tokenizer/codeTokenizer.ts
@@ -26,7 +26,11 @@ export class CodeTokenizer extends Tokenizer {
    */
   public static registerLanguage(language: string): void {
     try {
-      require("tree-sitter-" + language);
+      if (language === "elm") {
+        require("@elm-tooling/tree-sitter-elm");
+      } else {
+        require("tree-sitter-" + language);
+      }
     } catch (error) {
       throw new Error(
         `The module 'tree-sitter-${language}' could not be found. ` +
@@ -55,7 +59,12 @@ export class CodeTokenizer extends Tokenizer {
     this.language = language;
     this.parser = new Parser();
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const languageModule = require("tree-sitter-" + language);
+    let languageModule;
+    if (language === "elm") {
+      languageModule = require("@elm-tooling/tree-sitter-elm");
+    } else {
+      languageModule = require("tree-sitter-" + language);
+    }
     this.parser.setLanguage(languageModule);
   }
 

--- a/lib/src/lib/tokenizer/codeTokenizer.ts
+++ b/lib/src/lib/tokenizer/codeTokenizer.ts
@@ -58,11 +58,11 @@ export class CodeTokenizer extends Tokenizer {
 
     this.language = language;
     this.parser = new Parser();
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     let languageModule;
     if (language === "elm") {
       languageModule = require("@elm-tooling/tree-sitter-elm");
     } else {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       languageModule = require("tree-sitter-" + language);
     }
     this.parser.setLanguage(languageModule);


### PR DESCRIPTION
The `tree-sitter-elm` was scoped to `@elm-tooling/tree-sitter-elm`, the unscoped package has not been updated for over a year now and uses an older version of `tree-sitter`. See: https://www.npmjs.com/search?q=tree-sitter-elm

I'm not sure about the best way to handle this, maybe a lookup dictionary for known / tested languages? This would obviously require some maintenenace.

Another approach would be to check if `language` starts with `@` or contains `/`, in which case `language` should be interpreted as a package name.

I've included my quickfix here in case you don't want to make a decision on that (yet).