### PR TITLE
Refactor D3 Graph component

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@dodona/dolos-lib": "1.5.1",
     "@vue/composition-api": "^1.6.2",
+    "@vueuse/core": "^8.7.5",
     "pinia": "^2.0.14"
   },
   "license": "MIT",

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { ref } from "@vue/composition-api";
+import { ref, computed } from "@vue/composition-api";
 import { DATA_URL } from "@/api";
 import { File, ObjMap } from "@/api/models";
 import { useApiStore } from "@/api/stores";
@@ -12,6 +12,7 @@ import { colors, names, uniqueNamesGenerator } from "unique-names-generator";
 export const useFileStore = defineStore("files", () => {
   // List of files.
   const files = ref<ObjMap<File>>({});
+  const filesList = computed<File[]>(() => Object.values(files.value));
 
   // If this store has been hydrated.
   const hydrated = ref(false);
@@ -87,6 +88,7 @@ export const useFileStore = defineStore("files", () => {
 
   return {
     files,
+    filesList,
     hydrated,
     hydrate,
     populateFile,

--- a/web/src/api/stores/pair.store.ts
+++ b/web/src/api/stores/pair.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { ref } from "@vue/composition-api";
+import { ref, computed } from "@vue/composition-api";
 import { DATA_URL } from "@/api";
 import { assertType, fileToTokenizedFile } from "@/api/utils";
 import {
@@ -32,6 +32,7 @@ import {
 export const usePairStore = defineStore("pairs", () => {
   // List of pairs.
   const pairs = ref<ObjMap<Pair>>({});
+  const pairsList = computed<Pair[]>(() => Object.values(pairs.value));
 
   // If this store has been hydrated.
   const hydrated = ref(false);
@@ -176,6 +177,7 @@ export const usePairStore = defineStore("pairs", () => {
 
   return {
     pairs,
+    pairsList,
     hydrated,
     hydrate,
     populateFragments,

--- a/web/src/components/ClusteringTable.vue
+++ b/web/src/components/ClusteringTable.vue
@@ -2,98 +2,117 @@
   <v-card>
     <v-card-title>
       Clusters
-      <v-spacer></v-spacer>
+      <v-spacer />
       <form>
         <label>
           <div class="title-slider">Similarity ≥ {{ cutoff.toFixed(2) }}</div>
-          <input type="range" min="0.25" max="1" step="0.01" v-model="cutoff" />
+          <input
+            type="range"
+            min="0.25"
+            max="1"
+            step="0.01"
+            v-model.number="cutoff"
+          />
         </label>
       </form>
     </v-card-title>
+
     <v-expansion-panels v-model="panel">
       <ClusteringCard
-        v-for="(cluster, index) in sortedClustering()"
+        v-for="(cluster, index) in sortedClustering"
         :key="index"
         :cluster="cluster"
         :cutoff="cutoff"
         :id="`clustering-card-${index}`"
-      ></ClusteringCard>
+      />
     </v-expansion-panels>
   </v-card>
 </template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  PropType,
+  ref,
+  computed,
+  watch,
+} from "@vue/composition-api";
+import { storeToRefs } from "pinia";
+import { useVuetify, useRoute } from "@/composables";
+import { useApiStore } from "@/api/stores";
+import { Clustering, Cluster } from "@/util/clustering-algorithms/ClusterTypes";
+import { SortingFunction } from "@/util/Types";
+import { getClusterElements } from "@/util/clustering-algorithms/ClusterFunctions";
+import ClusteringCard from "@/components/clustering/ClusteringCard.vue";
+
+export default defineComponent({
+  props: {
+    currentClustering: {
+      type: Array as PropType<Clustering>,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    const vuetify = useVuetify();
+    const route = useRoute();
+    const { cutoff } = storeToRefs(useApiStore());
+
+    // Active expension panel.
+    const panel = ref(-1);
+
+    // Table headers
+    const headers = [
+      { text: "Cluster Id", value: "id", sortable: true },
+      { text: "Cluster Size", value: "size", sortable: true },
+      { text: "Average Similarity", value: "similarity" },
+    ];
+
+    // Table footer properties
+    const footerProps = {
+      itemsPerPageOptions: [15, 25, 50, 100, -1],
+      showCurrentPage: true,
+      showFirstLastPage: true,
+    };
+
+    // Clustering sorted on cluster size.
+    const sortedClustering = computed(() => {
+      const sortFn: SortingFunction<Cluster> = (a, b) =>
+        getClusterElements(b).size - getClusterElements(a).size;
+
+      return [...props.currentClustering].sort(sortFn);
+    });
+
+    // Watch for changes in the route when showing more info for a cluster.
+    watch(() => route.value.hash, (hash) => {
+      const hashNum = /[0-9]+/.exec(hash)?.[0];
+      if (hash.startsWith("#clustering-card") && hashNum) {
+        // Expand the correct panel.
+        panel.value = +hashNum;
+
+        // Scroll to the cluster card.
+        vuetify.goTo(hash);
+      }
+    });
+
+    return {
+      cutoff,
+      panel,
+      headers,
+      footerProps,
+      sortedClustering,
+    };
+  },
+
+  components: {
+    ClusteringCard,
+  },
+});
+</script>
 
 <style scoped>
 .title-slider {
   font-weight: 400;
   font-size: 1rem;
-}
-</style>
-
-<script lang="ts">
-import ClusteringCard from "@/components/clustering/ClusteringCard.vue";
-import {
-  getAverageClusterSimilarity,
-  getClusterElements
-} from "@/util/clustering-algorithms/ClusterFunctions";
-import { Clustering, Cluster } from "@/util/clustering-algorithms/ClusterTypes";
-import { SortingFunction } from "@/util/Types";
-import { Component, Prop, Watch } from "vue-property-decorator";
-import DataView from "@/views/DataView";
-
-@Component({
-  components: { ClusteringCard },
-})
-export default class ClusteringTable extends DataView {
-  @Prop() loaded!: boolean;
-  @Prop() currentClustering!: Clustering;
-  @Prop({ default: "" }) search!: string;
-
-  public panel = -1;
-
-  headers = [
-    { text: "Cluster Id", value: "id", sortable: true },
-    { text: "Cluster Size", value: "size", sortable: true },
-    { text: "Average Similarity", value: "similarity" },
-  ];
-
-  footerprops = {
-    itemsPerPageOptions: [15, 25, 50, 100, -1],
-    showCurrentPage: true,
-    showFirstLastPage: true,
-  };
-
-  @Watch("cutoff")
-  @Watch("files")
-  private emitCutoff(): void {
-    this.$emit("cutoffChange", this.cutoff);
-  }
-
-  private sortedClustering(): Clustering {
-    const sort: SortingFunction<Cluster> = (a, b) =>
-      getClusterElements(b).size - getClusterElements(a).size;
-
-    const toSort = [...this.currentClustering];
-    toSort.sort(sort);
-    return toSort;
-  }
-
-  @Watch("$route")
-  private onRouteChange(): void {
-    if (this.$route.hash) {
-      const hit = /[0-9]+/.exec(this.$route.hash)?.[0];
-      if (hit !== undefined) {
-        this.panel = +hit;
-        setTimeout(() => {
-          this.$vuetify.goTo(`#clustering-card-${this.panel}`);
-        }, 500);
-      }
-    }
-  }
-}
-</script>
-
-<style scoped>
-.v-data-table >>> tr:hover {
-  cursor: pointer;
 }
 </style>

--- a/web/src/components/clustering/ClusteringCard.vue
+++ b/web/src/components/clustering/ClusteringCard.vue
@@ -2,96 +2,111 @@
   <v-expansion-panel>
     <v-expansion-panel-header class="noflex">
       <div class="clustering-tag-container">
-        <FileTagList :current-files="clusterFiles(cluster)"></FileTagList>
+        <FileTagList :current-files="clusterFiles" />
       </div>
     </v-expansion-panel-header>
+
     <v-expansion-panel-content>
-      <v-tabs right v-model="activeTab">
-        <v-tab :key="1" :to="`/pairs/?showIds=${pairViewItems(cluster)}`">
-          Pair view
+      <v-tabs v-model="activeTab" right>
+        <v-tab :to="`/pairs/?showIds=${pairViewItems}`">
+          Pair View
         </v-tab>
-        <v-tab-item></v-tab-item>
 
-        <div class="empty-space"></div>
+        <div class="empty-space" />
 
-        <v-tab v-if="cluster && showClusterTimeline(cluster)" :key="2"
-          >Time Chart</v-tab
-        >
-        <v-tab-item v-if="cluster && showClusterTimeline(cluster)">
+        <v-tab v-if="cluster && showClusterTimeline">
+          Time Chart
+        </v-tab>
+
+        <v-tab>
+          Heatmap
+        </v-tab>
+
+        <v-tab>
+          Cluster
+        </v-tab>
+      </v-tabs>
+
+      <v-tabs-items v-model="activeTab">
+        <v-tab-item>
+          <!-- TODO: place pairs view here -->
+        </v-tab-item>
+
+        <v-tab-item v-if="cluster && showClusterTimeline">
           <TimeSeriesCard :cluster="cluster" />
         </v-tab-item>
 
-        <v-tab :key="4"> Heatmap </v-tab>
-        <v-tab-item> <HeatMap :cluster="cluster" /> </v-tab-item>
+        <v-tab-item>
+          <HeatMap :cluster="cluster" />
+        </v-tab-item>
 
-        <v-tab :key="5"> Cluster </v-tab>
-        <v-tab-item> <GraphTab :cluster="cluster" /> </v-tab-item>
-      </v-tabs>
+        <v-tab-item>
+          <GraphTab :cluster="cluster" />
+        </v-tab-item>
+      </v-tabs-items>
     </v-expansion-panel-content>
   </v-expansion-panel>
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop } from "vue-property-decorator";
-import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
 import {
-  getAverageClusterSimilarity,
-  getClusterElements,
-  getClusterElementsArray,
-} from "@/util/clustering-algorithms/ClusterFunctions";
-import { File } from "@/api/models";
+  defineComponent,
+  PropType,
+  ref,
+  computed,
+  toRef,
+} from "@vue/composition-api";
+import { useCluster } from "@/composables";
+import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
+import { getClusterElementsArray } from "@/util/clustering-algorithms/ClusterFunctions";
 import HeatMap from "./HeatMap.vue";
-import DataTab from "./DataTab.vue";
 import GraphTab from "./GraphTab.vue";
 import TimeSeriesCard from "./TimeSeriesCard.vue";
-import ClusteringFileTag from "@/components/clustering/ClusteringFileTag.vue";
 import FileTagList from "@/components/clustering/FileTagList.vue";
 
-@Component({
+export default defineComponent({
+  props: {
+    cluster: {
+      type: Set as PropType<Cluster>,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    const activeTab = ref(1);
+    const { clusterFiles } = useCluster(toRef(props, "cluster"));
+
+    // If the timeline should be shown.
+    // Timeline will only be shown if every cluster element has a timestamp.
+    const showClusterTimeline = computed(() => {
+      return getClusterElementsArray(props.cluster).every(
+        (e) => e.extra?.timestamp
+      );
+    });
+
+    // String of ids to show in the pair view.
+    // TODO: it may be better to inline the pair-table in the future for better UX.
+    const pairViewItems = computed(() => {
+      return Array.from(props.cluster)
+        .map((element) => element.id)
+        .join(",");
+    });
+
+    return {
+      clusterFiles,
+      activeTab,
+      showClusterTimeline,
+      pairViewItems,
+    };
+  },
+
   components: {
     HeatMap,
-    DataTab,
     GraphTab,
     TimeSeriesCard,
-    ClusteringFileTag,
     FileTagList,
   },
-})
-export default class ClusteringCard extends Vue {
-  @Prop() cluster!: Cluster;
-  @Prop() cutoff!: number;
-  private activeTab = 1;
-
-  averageSimilarity(cluster: Cluster): string {
-    return getAverageClusterSimilarity(cluster).toFixed(2);
-  }
-
-  getClusterElements(cluster: Cluster): Set<File> {
-    return getClusterElements(cluster);
-  }
-
-  public graphView(cluster: Cluster): void {
-    const items = getClusterElementsArray(cluster)
-      .map((c) => c.id)
-      .join(",");
-
-    this.$router.push(`/graph?cutoff=${this.cutoff}&red=${items}`);
-  }
-
-  public pairViewItems(cluster: Cluster): string {
-    const items = Array.from(cluster)
-      .map((v) => v.id)
-      .join(",");
-
-    return items;
-  }
-
-  public showClusterTimeline(cluster: Cluster): boolean {
-    return getClusterElementsArray(cluster).every((f) => f.extra?.timestamp);
-  }
-
-  public clusterFiles = getClusterElementsArray;
-}
+});
 </script>
 
 <style scoped>

--- a/web/src/components/graph/Graph.vue
+++ b/web/src/components/graph/Graph.vue
@@ -1,462 +1,326 @@
-<!-- eslint-disable -->
 <template>
   <div ref="container" class="graph-container">
     <!-- Extra (optional) UI elements can be added to this container  -->
-    <slot></slot>
+    <slot />
   </div>
 </template>
 
-<script>
+<script lang="ts">
 /* eslint-disable */
 
-import {Component, Prop, Watch} from "vue-property-decorator";
+import { defineComponent, PropType, ref, computed, watch, onMounted, nextTick } from "@vue/composition-api";
+import { useApiStore } from "@/api/stores";
+import { Pair, File } from "@/api/models";
+import { useCluster } from "@/composables";
+import { storeToRefs } from "pinia";
+import { useElementSize } from "@vueuse/core";
+import { Clustering, Cluster } from "@/util/clustering-algorithms/ClusterTypes";
+import { getClusterElements, getClusterIntersect } from "@/util/clustering-algorithms/ClusterFunctions";
+import { ConvexHullTool } from "@/d3-tools/ConvexHullTool";
+import { DefaultMap } from "@dodona/dolos-lib";
 import * as d3 from "d3";
-import {ConvexHullTool} from "@/d3-tools/ConvexHullTool";
-import {getClusterElements, getClusterIntersect} from "@/util/clustering-algorithms/ClusterFunctions";
-import {DefaultMap} from "@dodona/dolos-lib";
 
-@Component()
-export default class PlagarismGraph {
-  queryColorMap;
-  @Prop() files;
-  @Prop() pairs;
-  @Prop() cutoff;
-  @Prop() showSingletons;
-  @Prop({default: {}}) legend;
-  @Prop({default: true}) polygon;
-  @Prop() clustering;
-  @Prop() zoomTo;
-  @Prop({ default: null }) selectedNode;
+export default defineComponent({
+  props: {
+    showSingletons: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
 
+    legend: {
+      default: () => [],
+    },
 
-  created() {
-    this.updateRoute();
-    const svg = d3.create("svg").attr("viewBox", [0, 0, 500, 500]);
-    svg.on("mousedown.s", () => {this.selectCluster(null, null); this.removeSelectedNode();})
+    polygon: {
+      type: Boolean as PropType<boolean>,
+      default: true,
+    },
 
-    const container = svg.append("g");
-    this.zoom = d3.zoom().on("zoom", (event) => {
-      container.attr("transform", event.transform);
-    });
-    //svg.call(this.zoom);
+    clustering: {
+      type: Array as PropType<Clustering>,
+      default: () => [],
+    },
 
-    if(this.zoomTo)
-      this.drawChevron(svg);
+    files: {
+      type: Array as PropType<File[]>,
+      default: () => [],
+    },
 
+    pairs: {
+      type: Array as PropType<Pair[]>,
+      default: () => [],
+    },
 
-    const defs = svg.append("svg:defs");
-    defs
-      .append("svg:marker")
-      .attr("id", "arrow-marker")
-      .attr("viewBox", "0 -6 10 12")
-      .attr("refX", "5")
-      .attr("markerWidth", 2)
-      .attr("markerHeight", 2)
-      .attr("orient", "auto")
-      .append("svg:path")
-      .attr("d", "M5,-5L10,0L5,5M10,0L0,0");
+    zoomTo: {
+      type: String as PropType<string>,
+      default: "",
+    },
 
-    this.svg = svg;
-    this.svgLinks = container.append("g");
-    this.svgNodes = container.append("g");
+    selectedNode: {
+      type: Object as PropType<File>,
+      default: () => ({}),
+    },
+  },
 
-    this.simulation = d3
-      .forceSimulation()
-      .alphaDecay(0.01)
-      .force(
-        "link",
-        d3
-          .forceLink()
-          .id((d) => d.id)
-          .strength(
-            (link) =>
-              Math.pow(Math.max(0.4, (link.similarity - 0.8) / 0.2), 3) /
-              Math.min(
-                link.source.neighbors.length,
-                link.target.neighbors.length
-              )
-          )
-      )
-      .force("charge", d3.forceManyBody().distanceMax(200).strength(-20))
-      .force("center", d3.forceCenter(this.width / 2, this.height / 2))
-      .force("compact_x", d3.forceX(this.width / 2).strength(0.01))
-      .force("compact_y", d3.forceY(this.height / 2).strength(0.01));
+  setup(props, { emit }) {
+    const { cutoff } = storeToRefs(useApiStore());
 
-    this.simulation.on("tick", () => {
-      if (this.svgLink)
-        this.svgLink.attr("d", (d) => {
-          const { x: x0, y: y0 } = d.source;
-          const { x: x1, y: y1 } = d.target;
-          return `M${x0},${y0}L${0.5 * (x0 + x1)},${
-            0.5 * (y0 + y1)
-          }L${x1},${y1}`;
+    // Reference to the container element.
+    const container = ref<HTMLElement>();
+    // Container size
+    const { width, height } = useElementSize(container);
+
+    // Selected cluser
+    const selectedCluster = ref<Cluster | null>(null);
+    const selectedClusterMeta = useCluster(selectedCluster);
+
+    // Map of nodes (files) in the graph.
+    //  - key: file id
+    //  - value: node object
+    //
+    // This map contains ALL nodes (also singletons/invisible nodes).
+    const nodesMap = computed(() => {
+      const nodesMap = new Map<number, any>();
+      for (const file of props.files) {
+        const label = file.extra.labels ?? "N/A";
+        const labels = props.legend as any[];
+        const visible = labels[label] ? labels[label].selected : true;
+
+        nodesMap.set(file.id, {
+          id: file.id,
+          file,
+          x: width.value * Math.random(),
+          y: height.value * Math.random(),
+          vx: 0,
+          vy: 0,
+          component: -1,
+          neighbors: [],
+          edges: [],
+          label,
+          visible,
         });
-
-      if (this.svgNode)
-        this.svgNode.attr("cx", (d) => d.x || 0).attr("cy", (d) => d.y || 0);
-
-      if(this.hullTool && this.nodes.length && this.clustering) {
-        this.hullTool.clear();
-
-        for(const cluster of this.clustering) {
-          // If any cluster is selected, make sure only the selected cluster is colored.
-          // Else, color the cluster in the most appropriate color.
-          const color = this.selectedCluster ?
-            (this.selectedCluster === cluster ? (this.clusterColors.get(cluster)?.color || "blue") : "grey") :
-            this.clusterColors.get(cluster)?.color || "blue";
-
-          const elements = getClusterElements(cluster);
-          this.hullTool.addConvexHullFromNodes(
-            this.nodes.filter(n => elements.has(n.file)),
-            color,
-            cluster);
-        }
       }
 
+      return nodesMap;
     });
 
-    this.resizeHandler = () => {
-      this.width = this.$refs.container.clientWidth || this.width;
-      this.height = this.$refs.container.clientHeight || this.height;
+    // List of edges to display in the graph.
+    const edges = ref();
+
+    // List of node to display in the graph.
+    const nodes = ref();
+
+    // Cluster colors
+    const clusterColors = computed(() => {
+      const clusterColorsMap = new Map<Cluster, string>();
+      const labels = props.legend as any[];
+
+      for (const cluster of props.clustering) {
+        const elements = getClusterElements(cluster);
+
+        // Count for each label the number of files in the cluster.
+        const counter = new DefaultMap(() => 0);
+        for (const element of elements) {
+          counter.set(element.extra.labels, counter.get(element.extra.labels) + 1)
+        }
+
+        // Find the label with the most files in the cluster.
+        let maxKey = 0;
+        for (const [key, count] of counter.entries()) {
+          if (count > counter.get(maxKey)) maxKey = key;
+        }
+
+        clusterColorsMap.set(cluster, labels[maxKey].color);
+      }
+
+      return clusterColorsMap;
+    });
+
+    // SVG element of the simulation.
+    const graph = d3.create("svg").attr("viewBox", [0, 0, 500, 500]);
+
+    // If the graph has been rendered the first time.
+    const graphInitialized = ref(false);
+
+    // Edges between nodes in the graph.
+    const graphEdgesBase = graph.append("g");
+    const graphEdges = ref();
+
+    // Nodes in the graph.
+    const graphNodesBase = graph.append("g");
+    const graphNodes = ref();
+
+    // Convex hull tool for creating hulls around clusters.
+    const graphHullTool = ref();
+
+    // Select a cluster
+    const selectCluster = (cluster: Cluster | null, coordinates: any): void => {
+      selectedCluster.value = cluster;
+      emit("selectedClusterInfo", cluster);
     };
-    window.addEventListener("resize", this.resizeHandler);
-    this.recluster();
-    this.updateGraph();
-  }
-  data() {
-    return {
-      nodes: [],
-      links: [],
-      width: 100,
-      height: 100,
-      selectedCluster: undefined,
+
+    // Select a node
+    const selectNode = (node: any | null): void => {
+      emit("selectedNodeInfo", node);
+
+      // Deselect all other nodes.
+      nodes.value.forEach(n => n.selected = false);
+      graph.select(".selected").classed("selected", false);
+
+      // Select the new node (if not null).
+      if (node) {
+        node.selected = true;
+        graph.select(`#circle-${node.id}`).classed("selected", true);
+      }
     };
-  }
+    
+    // Handler for clicking on empty void in the graph.
+    // Deselect the node & cluster.
+    graph.on("mousedown.s", () => {
+      selectNode(null);
+      selectCluster(null, null);
+    });
 
-  selectCluster(cluster, coordinates) {
-    this.selectedCluster = cluster;
-    this.updateGraph(false);
-
-    if(cluster) {
-      this.zoomToCenter(coordinates);
-    }
-  }
-
-  zoomToCenter(coordinates) {
-    const d3Coordinates = coordinates.map(v => [v.x, v.y]);
-
-    if(d3Coordinates.length > 2) {
-      const polygon = d3.polygonHull(d3Coordinates);
-      polygon.push(polygon[0]);
-      const [cx, cy] = d3.polygonCentroid(polygon);
-
-      this.zoom.translateTo(this.svg, cx , cy )
-    } else if (d3Coordinates.length === 2) {
-      const [[x1, y1], [x2, y2]] = d3Coordinates;
-      const [cx, cy] = [(x1 + x2) / 2, (y1 + y2) / 2];
-
-      this.zoom.translateTo(this.svg, cx , cy )
-    }
-  }
-
-  @Watch("$route")
-  updateRoute() {
-    this.queryColorMap = this.getQueryColorMap();
-    if (this.resizeHandler) this.resizeHandler();
-  }
-
-  @Watch("$refs.container")
-  updateSize() {
-    this.resizeHandler();
-  }
-
-  @Watch("width")
-  @Watch("height")
-  updateSize() {
-    window.simulation = this.simulation;
-    this.svg.attr("viewBox", [0, 0, this.width, this.height]);
-    this.simulation.force("compact_x").x(this.width / 2);
-    this.simulation.force("compact_y").y(this.height / 2);
-    this.simulation
-      .force("center")
-      .x(this.width / 2)
-      .y(this.height / 2);
-
-    const scale =  this.height / 1080;
-
-    this.svg.select(".chevron").attr("transform", `translate(${this.width / 2 - 150}, ${this.height - 200}) scale(${scale})`);
-  }
-
-  @Watch("cutoff")
-  @Watch("files")
-  @Watch("showSingletons")
-  @Watch("legend")
-  updateGraph() {
-    setTimeout(() => this.resizeHandler(), 50);
-
-    if (this.delayUpdateGraph >= 0) clearTimeout(this.delayUpdateGraph);
-    this.delayUpdateGraph = setTimeout(() => {
-      this.delayUpdateGraph = -1;
-      const nodeMap = this.getRawNodeMap();
-      const labels = this.legend;
-      Object.values(nodeMap).forEach((node) => {
-        node.component = -1;
-        node.neighbors = [];
-        node.links = [];
-        node.visible = labels[node.label]? labels[node.label].selected:true;
-      });
-      this.links = Object.entries(this.pairs)
-        .filter(([key, value]) => value.similarity >= this.cutoff)
-        .filter(
-          ([_, { leftFile, rightFile }]) =>
-            nodeMap[leftFile.id].visible && nodeMap[rightFile.id].visible
-        )
-        .map(([key, value]) => {
-          let left = nodeMap[value.leftFile.id];
-          let right = nodeMap[value.rightFile.id];
+    // Calculate the edges of the graph.
+    const calculateEdges = (): any[] => {
+      return edges.value = props.pairs
+        // Filter pairs with a similarity lower than the cutoff
+        .filter(pair => pair.similarity >= cutoff.value)
+        // Filter pairs where one of the files is not visible.
+        .filter(pair => {
+          const left = nodesMap.value.get(pair.leftFile.id);
+          const right = nodesMap.value.get(pair.rightFile.id);
+          return left.visible && right.visible;
+        })
+        // Map the pair to an edge object.
+        .map(pair => {
+          const left = nodesMap.value.get(pair.leftFile.id);
           const leftInfo = left.file.extra;
+          const right = nodesMap.value.get(pair.rightFile.id);
           const rightInfo = right.file.extra;
+
+          // If the edge is directed.
+          // This is the case when both files contain a creation date.
           const directed = leftInfo.createdAt && rightInfo.createdAt;
-          if (directed && rightInfo.createdAt < leftInfo.createdAt)
-            [left, right] = [right, left];
+
+          // Determine the source & target nodes.
+          let source = left;
+          let target = right;
+          // Switch the source & target when the right node is older than the left node.
+          if (directed && rightInfo.createdAt < leftInfo.createdAt) {
+            source = right;
+            target = left;
+          }
+
+          // Add the the nodes to eachother's neighbors list.
           left.neighbors.push(right);
           right.neighbors.push(left);
-          const similarity = value.similarity;
-          const link = {
-            id: key,
-            directed: directed,
-            source: left,
-            target: right,
-            similarity,
-            linkWidth:
-              4 * Math.pow(Math.max(0.4, (similarity - 0.75) / 0.2), 2),
+
+          // Create the edge object.
+          const edge = {
+            id: pair.id,
+            directed,
+            source,
+            target,
+            similarity: pair.similarity,
+            width: 4 * Math.pow(Math.max(0.4, (pair.similarity - 0.75) / 0.2), 2)
           };
-          left.links.push(link);
-          right.links.push(link);
-          return link;
+
+          // Add the edge to the source & target nodes.
+          source.edges.push(edge);
+          target.edges.push(edge);
+
+          return edge;
         });
-      let component = 0;
-      Object.values(nodeMap).forEach((node) => {
-        if (node.component < 0) {
-          node.component = ++component;
-          const checkNode = [node];
-          while (checkNode.length) {
-            checkNode.pop().neighbors.forEach((n) => {
-              if (n.component < 0) {
-                n.component = component;
-                checkNode.push(n);
-              }
-            });
-          }
-        }
-      });
+    }
 
-      this.nodes = Object.values(nodeMap).filter((n) => n.visible);
-      if (!this.showSingletons) {
-        this.nodes = this.nodes.filter((n) => n.neighbors.length);
-      }
-
-      this.nodes.forEach((node, index) => {
-        node.index = index;
+    // Calculate the nodes of the graph.
+    const calculateNodes = (): any[] => {
+      const labels = props.legend as any[];
+      const nodesList = Array.from(nodesMap.value.values())
+        // Only display the nodes that are visible.
+        .filter(node => node.visible)
+        // Only display the nodes that have neighbors.
+        // Unless singletons are enabled.
+        .filter(node => node.neighbors.length > 0 || props.showSingletons)
+      
+      for (const node of nodesList) {
+        // Determine if the node is the source of a cluster.
         let incoming = 0;
         let outgoing = 0;
-        node.links.forEach((l) => {
-          if (l.directed) {
-            if (l.target === node) ++incoming;
-            else ++outgoing;
+        
+        for (const edge of node.edges) {
+          if (edge.directed) {
+            if (edge.source.id === node.id) incoming++;
+            else outgoing++;
           }
-        });
-        node.source = outgoing > 1 && incoming === 0;
-
-
-        const getDefaultNodeColor = (n) =>  !labels[n.label] ? d3.schemeCategory10[0]:labels[n.label].color
-        let color;
-        if(this.selectedCluster) {
-          color = getClusterElements(this.selectedCluster).has(node.file) ? getDefaultNodeColor(node) : "grey";
-        } else {
-          color = getDefaultNodeColor(node)
         }
-        node.fillColor = color;
-      });
 
-      this.recluster();
+        // Node is the source of a cluster when
+        // * there is at least one outgoing edge
+        // * there are no incoming edges
+        node.source = outgoing > 0 && incoming === 0;
 
-      if(this.hullTool)
-        this.hullTool.clear();
-    }, 50);
-  }
-
-  @Watch("clustering")
-  recluster() {
-    this.setupClusterColors(this.clustering);
-
-    if(this.selectedCluster) {
-      const intersects = this.clustering.filter(c => getClusterIntersect(c, this.selectedCluster).size > 0);
-      if(intersects.length > 0)
-        this.selectedCluster = intersects[0];
-    }
-  }
-
-  removeSelectedNode() {
-    if (this.selectedNode !== null) {
-      this.emitSelectedNode(null);
-    }
-  }
-
-  setupClusterColors(clustering) {
-    this.clusterColors = new Map();
-    for(const cluster of clustering) {
-      const els = getClusterElements(cluster);
-      const counter = new DefaultMap(() => 0);
-      for (const el of els) {
-        counter.set(el.extra.labels, counter.get(el.extra.labels) + 1)
+        // Determine the color of the node.
+        const defaultColor = labels[node.label] ? labels[node.label].color : d3.schemeCategory10[0];
+        // When a cluster is selected
+        // Make all other nodes gray, except for the nodes in the cluster.
+        if (selectedCluster.value) {
+          node.fillColor = selectedClusterMeta.clusterFilesSet.value.has(node.file) ? defaultColor : "grey";
+        } else {
+          node.fillColor = defaultColor;
+        }
       }
 
-      let maxKey = undefined;
-      for ( const [key, count] of counter.entries()) {
-        if(count > counter.get(maxKey))
-          maxKey = key;
+      return nodesList;
+    }
+
+    // Update the graph
+    const updateGraph = () => {
+      // Clear side-effects, caused by previous calculations.
+      for (const node of nodesMap.value.values()) {
+        node.component = -1;
+        node.neighbors = [];
+        node.edges = [];
       }
 
-      this.clusterColors.set(cluster, this.legend[maxKey]);
-    }
-  }
-
-  drawChevron(svg) {
-    const chevron = svg
-      .append("g")
-      .attr("class", "chevron")
-      .append("path")
-      .attr("d", d3.line()([[0,0], [125,75 ], [250,0]]))
-      .attr("stroke", "black")
-      .attr("fill", "none")
-      .style("stroke-width", 15)
-      .style("stroke-opacity", 0.1)
-      .style("cursor", "pointer")
-      .attr("stroke-linecap", "round")
-      .attr("stroke-linejoin", "round");
-
-    chevron.on("mouseenter", () => chevron.style("stroke-opacity", 0.2));
-    chevron.on("mouseleave", () => chevron.style("stroke-opacity", 0.1));
-
-    chevron.on("click", () => this.$vuetify.goTo(this.zoomTo));
-  }
-
-  @Watch("pairs")
-  @Watch("files")
-  clearCachedNodemap() {
-    this._nodeMap = null;
-  }
-
-  getRawNodeMap() {
-    if (this._nodeMap) return this._nodeMap;
-    if (Object.entries(this.files).length === 0) return {};
-
-    const nodeMap = {};
-    let labels = new Set();
-    Object.entries(this.files).forEach(([key, value]) => {
-      const label = value.extra.labels || "N/A";
-      labels.add(label);
-      nodeMap[value.id] = {
-        id: key,
-        file: value,
-        component: -1,
-        neighbors: [],
-        label: label,
-        x: this.width * Math.random(),
-        y: this.height * Math.random(),
-        vx: 0,
-        vy: 0,
-      };
-    });
-    const colorScale = d3
-      .scaleOrdinal(d3.schemeCategory10)
-      .domain([...labels].reverse());
-    labels = [...labels].sort().map((p) => ({
-      label: p,
-      selected: true,
-      color: colorScale(p),
-    }));
-    // this.legend = Object.fromEntries(labels.map((p) => [p.label, p]));
-    return (this._nodeMap = nodeMap);
-  }
-
-  getQueryColorMap() {
-    const map = new Map();
-    const { cutoff, ...colors } = this.$route.query;
-
-    for (const [color, nodelist] of Object.entries(colors)) {
-      const ids = nodelist.split(",").map((v) => +v);
-      ids.forEach((v) => map.set(v, color));
+      // Update the edges.
+      edges.value = calculateEdges();
+      // Update the nodes.
+      nodes.value = calculateNodes();
     }
 
-    return map;
-  }
+    // Update the graph when the data changes.
+    watch(
+      () => [cutoff.value, props.showSingletons, ],
+      () => updateGraph()
+    );
 
-  @Watch("nodes")
-  @Watch("links")
-  updateSimulation() {
-    this.svgLink = this.svgLinks
-      .selectAll("path")
-      .data(this.links)
-      .join("path")
-      .classed("link", true)
-      .classed("directed", (d) => d.directed)
-      .attr("stroke-width", (d) => d.linkWidth)
-    ;
+    // D3 Simulation force link
+    const forceLink = d3
+      .forceLink()
+      .id((d: any) => d.id)
+      .strength(
+        (link: any) =>
+          Math.pow(Math.max(0.4, (link.similarity - 0.8) / 0.2), 3) /
+          Math.min(link.source.neighbors.length, link.target.neighbors.length)
+      );
 
-    this.svgNode = this.svgNodes
-      .selectAll("circle")
-      .data(this.nodes)
-      .join("circle")
-      .classed("node", true)
-      .classed("source", (d) => d.source)
-      .attr("r", 5)
-      .attr("fill", (d) => d.fillColor)
-      .attr("id", n => `circle-${n.file.id}`)
-      .call(this.drag());
+    // D3 simulation
+    const simulation = d3
+      .forceSimulation()
+      .alphaDecay(0.1)
+      .force("link", forceLink)
+      .force("charge", d3.forceManyBody().distanceMax(200).strength(-20))
+      .force("center", d3.forceCenter(width.value / 2, height.value / 2))
+      .force("compact_x", d3.forceX(width.value / 2).strength(0.01))
+      .force("compact_y", d3.forceY(height.value / 2).strength(0.01));
 
-    if(this.hullTool)
-      this.hullTool.clear();
-
-    if(this.polygon)
-      this.hullTool = new ConvexHullTool(this.svg.select("g"), this.selectCluster);
-
-    this.simulation.nodes(this.nodes);
-    this.simulation.alpha(0.5).alphaTarget(0.3).restart();
-    this.simulation.force("link").links(this.links);
-  }
-
-  emitSelectedNode(node) {
-    this.$emit("selectedNodeInfo", node);
-  }
-
-  @Watch("selectedCluster")
-  emitCluster() {
-    this.$emit("selectedClusterInfo", this.selectedCluster);
-  }
-
-  @Watch("selectedNode")
-  onSelectedNode() {
-    this.nodes.forEach(v => v.selected = false);
-    this.svg.select(".selected").classed("selected", false);
-    if(this.selectedNode) {
-
-      this.nodes.find(n => n.file.id === this.selectedNode.id).selected = true;
-      this.svgNodes.select(`#circle-${this.selectedNode.id}`).classed("selected", true);
-    }
-  }
-
-  mounted() {
-    this.$refs.container.prepend(this.svg.node());
-    this.resizeHandler();
-  }
-
-  drag() {
-    return d3
+    // D3 Simulation Drag ability
+    const simulationDrag = d3
       .drag()
       .on("start", (event) => {
-        if (!event.active) this.simulation.alphaTarget(0.3).restart();
+        if (!event.active) simulation.alphaTarget(0.3).restart();
         event.subject.fx = event.subject.x;
         event.subject.fy = event.subject.y;
         event.subject.justDragged = false;
@@ -467,29 +331,132 @@ export default class PlagarismGraph {
         event.subject.justDragged = true;
       })
       .on("end", (event) => {
-        if (!event.active) this.simulation.alphaTarget(0);
+        if (!event.active) simulation.alphaTarget(0);
         event.subject.fx = null;
         event.subject.fy = null;
+
+        // When the user clicks on the graph.
         if (!event.subject.justDragged) {
-          // clicked
-          if (event.subject.file && this.selectedNode && (event.subject.file.id === this.selectedNode.id)) {
-            this.removeSelectedNode();
-          } else {
-            this.emitSelectedNode(event.subject.file);
+          // Toggle the selected file.
+          if (event.subject.file && props.selectedNode && event.subject.file.id === props.selectedNode.id) {
+            selectNode(null);
+          }
+          // Click on a file.
+          else {
+            selectNode(event.subject.file);
           }
         }
       });
-  }
 
-  toCompareView(diff) {
-    this.$router.push(`/compare/${diff.id}`);
-  }
+    // Handler for every tick in the simulation.
+    // A "tick" is a simulation step.
+    simulation.on("tick", () => {
+      if (graphEdges.value) {
+        graphEdges.value.attr("d", (edge: any) => {
+          const { x: x0, y: y0 } = edge.source;
+          const { x: x1, y: y1 } = edge.target;
+          return `M${x0},${y0}L${0.5 * (x0 + x1)},${0.5 * (y0 + y1)}L${x1},${y1}`;
+        });
+      }
 
-  destroyed() {
-    this.simulation.stop();
-    window.removeEventListener("resize", this.resizeHandler);
-  }
-}
+      if (graphNodes.value) {
+        graphNodes.value
+          .attr("cx", (node: any) => node.x ?? 0)
+          .attr("cy", (node: any) => node.y ?? 0);
+      }
+
+      if (graphHullTool.value) {
+        graphHullTool.value.clear();
+
+        for (const cluster of props.clustering) {
+          // If any cluster is selected, make sure only the selected cluster is colored.
+          // Else, color the cluster in the most appropriate color.
+          let color = clusterColors.value.get(cluster);
+          if (selectedCluster.value && selectedCluster.value === cluster) color = color ?? "blue";
+          if (selectedCluster.value && selectedCluster.value !== cluster) color = "grey";
+
+          // Add convex hull to the cluster.
+          const elements = getClusterElements(cluster);
+          graphHullTool.value.addConvexHullFromNodes(
+            nodes.value.filter(node => elements.has(node.file)),
+            color,
+            cluster
+          );
+        }
+      }
+    });
+
+    // Watch changes to the nodes and update the rendered graph nodes/edges.
+    watch(
+      () => [edges.value, nodes.value],
+      ([edges, nodes]) => {
+        // Create the edges
+        graphEdges.value = graphEdgesBase
+          .selectAll("path")
+          .data(edges)
+          .join("path")
+          .classed("link", true)
+          .classed("directed", (edge: any) => edge.directed)
+          .attr("stroke-width", (edge: any) => edge.linkWidth)
+
+        // Create the nodes
+        graphNodes.value = graphNodesBase
+          .selectAll("circle")
+          .data(nodes)
+          .join("circle")
+          .classed("node", true)
+          .classed("source", (node: any) => node.source)
+          .attr("r", 5)
+          .attr("fill", (node: any) => node.fillColor)
+          .attr("id", (node: any) => `circle-${node.file.id}`)
+          .call(simulationDrag);
+
+        // Create the Convex Hull around every cluster.
+        // A Convex Hull is a polygon that encloses all the nodes in the cluster.
+        if (props.polygon) {
+          // Clear the convex hull, if it exists.
+          graphHullTool.value?.clear();
+
+          // Create the convex hull.
+          graphHullTool.value = new ConvexHullTool(graph.select("g"), selectedCluster.value);
+        }
+
+        // Set the nodes/edges of the simulation.
+        simulation.nodes(nodes);
+        simulation.force("link").links(edges);
+        simulation.alpha(0.5).alphaTarget(0.3).restart();
+      }
+    );
+
+    // Watch width/height changes & update the graph size.
+    watch(
+      () => [width.value, height.value],
+      ([width, height]) => {
+        // Resize the graph.
+        graph.attr("viewBox", [0, 0, width, height]);
+
+        // Resize the simulation.
+        simulation.force("compact_x").x(width / 2);
+        simulation.force("compact_y").y(height / 2);
+        simulation.force("center").x(width / 2) .y(height / 2);
+
+        // Update the graph when not yet initialized.
+        // This must be done here, since the initial size of the graph is otherwise incorrect.
+        if (!graphInitialized.value) {
+          graphInitialized.value = true;
+          updateGraph();
+        }
+      }
+    );
+
+    // Add the graph to the container.
+    onMounted(() => container.value?.prepend(graph.node()));
+
+    return {
+      container,
+    };
+  },
+});
 </script>
 
 <style lang="scss">
@@ -522,11 +489,12 @@ export default class PlagarismGraph {
       &.source {
         stroke-width: 0;
       }
+      
       &.selected {
         stroke: red;
-        stroke-dasharray: 1.14, 2;
-        stroke-width: 1;
+        stroke-width: 2;
       }
+
       &:hover {
         cursor: grab;
       }

--- a/web/src/components/graph/Graph.vue
+++ b/web/src/components/graph/Graph.vue
@@ -170,6 +170,11 @@ export default defineComponent({
     const selectCluster = (cluster: Cluster | null, coordinates: any): void => {
       selectedCluster.value = cluster;
       emit("selectedClusterInfo", cluster);
+
+      // The graph must be updated to update the fills of the nodes.
+      // This is not the most efficient implementation and can definitely be improved.
+      // For the simplicity of the refactor to the Composition API, this is taken from the previous version for now.
+      updateGraph();
     };
 
     // Select a node
@@ -430,7 +435,7 @@ export default defineComponent({
           graphHullTool.value?.clear();
 
           // Create the convex hull.
-          graphHullTool.value = new ConvexHullTool(graph.select("g"), selectedCluster.value);
+          graphHullTool.value = new ConvexHullTool(graph.select("g"), selectCluster);
         }
 
         // Set the nodes/edges of the simulation.

--- a/web/src/composables/index.ts
+++ b/web/src/composables/index.ts
@@ -4,3 +4,4 @@ export * from "./useRouter";
 export * from "./useRoute";
 export * from "./useLegend";
 export * from "./useClustering";
+export * from "./useCluster";

--- a/web/src/composables/useCluster.ts
+++ b/web/src/composables/useCluster.ts
@@ -1,0 +1,49 @@
+import { ComputedRef, computed, unref } from "@vue/composition-api";
+import { MaybeRef } from "@/util/Types";
+import { File } from "@/api/models";
+import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
+import {
+  getAverageClusterSimilarity,
+  getClusterElements,
+  getClusterElementsArray,
+} from "@/util/clustering-algorithms/ClusterFunctions";
+
+/**
+ * Return type for the composable.
+ */
+export interface UseClusterReturn {
+  clusterFiles: ComputedRef<File[]>;
+  clusterFilesSet: ComputedRef<Set<File>>;
+  clusterAverageSimilarity: ComputedRef<number>;
+}
+
+/**
+ * Calculate the clustering.
+ */
+export function useCluster(
+  cluster: MaybeRef<Cluster | null | undefined>
+): UseClusterReturn {
+  // List of files in the cluster.
+  const clusterFiles = computed(() => {
+    const value = unref(cluster);
+    return value ? getClusterElementsArray(value) : [];
+  });
+
+  // Set of files in the cluster.
+  const clusterFilesSet = computed(() => {
+    const value = unref(cluster);
+    return value ? getClusterElements(value) : new Set<File>();
+  });
+
+  // Average similarity of the cluster.
+  const clusterAverageSimilarity = computed(() => {
+    const value = unref(cluster);
+    return value ? getAverageClusterSimilarity(value) : 0;
+  });
+
+  return {
+    clusterFiles,
+    clusterFilesSet,
+    clusterAverageSimilarity,
+  };
+}

--- a/web/src/d3-tools/GraphSelectedInfo.vue
+++ b/web/src/d3-tools/GraphSelectedInfo.vue
@@ -1,85 +1,136 @@
 <template>
-<div class="selected-info">
-  <div v-if="selectedNodeInfo">
-    <v-card elevation="2" outlined>
-      <v-card-title>
-        Selected node
-      </v-card-title>
+  <div class="selected-info">
+    <div v-if="selectedNode">
+      <v-card elevation="2" outlined>
+        <v-card-title> Selected node </v-card-title>
 
-      <v-card-text>
-        The author of this submission is <b>{{selectedNodeInfo.extra.fullName || "unknown"}}</b>, belonging to group
-        <b>{{selectedNodeInfo.extra.labels}}</b>. The last hand-in date was <b>{{
-          selectedNodeInfo.extra.timestamp ?
-            DateTime.fromJSDate(selectedNodeInfo.extra.timestamp).toLocaleString(DateTime.DATETIME_MED)
-            :
-            "not available."
-        }}</b>.
-      </v-card-text>
-    </v-card>
+        <v-card-text>
+          The author of this submission is
+          <b>{{ selectedNode.extra.fullName || "unknown" }}</b>
+          , belonging to group
+          <b>{{ selectedNode.extra.labels }}</b>
+          . The last hand-in date was
+          <b>{{ selectedNodeTimestamp || "not available." }}</b
+          >.
+        </v-card-text>
+      </v-card>
+    </div>
+
+    <div v-if="selectedCluster">
+      <v-card elevation="2" outlined>
+        <v-card-title> Selected cluster </v-card-title>
+
+        <v-card-text>
+          You selected a cluster of size
+          <b>{{ clusterFilesSet.size }}</b>
+          , which has an average similarity of
+          <b>{{ clusterAverageSimilarity.toFixed(2) * 100 }}%</b>.
+        </v-card-text>
+
+        <v-card-text class="namecontainer">
+          These files are present in the cluster:
+          <ul>
+            <li v-for="el of clusterFilesSet" :key="el.id">
+              {{ el.path.split("/").slice(-2).join("/") }}
+            </li>
+          </ul>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+          <v-btn color="success" text @click="goToInfo">More information</v-btn>
+        </v-card-actions>
+      </v-card>
+    </div>
   </div>
-  <div v-if="selectedCluster">
-    <v-card elevation="2" outlined>
-      <v-card-title>
-        Selected cluster
-      </v-card-title>
-
-      <v-card-text>
-        You selected a cluster of size <b>{{getClusterElements(selectedCluster).size}}</b>, which has an average
-        similarity of  <b>{{getAverageClusterSimilarity(selectedCluster).toFixed(2) * 100}}%</b>.
-      </v-card-text>
-      <v-card-text class="namecontainer">
-        These files are present in the cluster:
-        <ul>
-          <li v-for="el of getClusterElements(selectedCluster)" :key="el.id">
-            {{el.path.split("/").slice(-2).join("/")}}
-          </li>
-        </ul>
-      </v-card-text>
-      <v-card-actions>
-      <v-btn color="success" text @click="goToInfo">More information</v-btn>
-      </v-card-actions>
-    </v-card>
-
-  </div>
-</div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from "vue-property-decorator";
-import { Cluster, Clustering } from "@/util/clustering-algorithms/ClusterTypes";
-import { getAverageClusterSimilarity, getClusterElements } from "@/util/clustering-algorithms/ClusterFunctions";
+import {
+  defineComponent,
+  PropType,
+  computed,
+  toRef,
+} from "@vue/composition-api";
+import { useCluster, useVuetify, useRouter } from "@/composables";
 import { File } from "@/api/models";
+import { Cluster, Clustering } from "@/util/clustering-algorithms/ClusterTypes";
 import { DateTime } from "luxon";
+import { getClusterElements } from "@/util/clustering-algorithms/ClusterFunctions";
 
-@Component({})
-export default class GraphSelectedInfo extends Vue {
-  @Prop() selectedNodeInfo!: File;
-  @Prop() selectedCluster! : Cluster | null;
-  @Prop() currentClustering!: Clustering;
+export default defineComponent({
+  props: {
+    currentClustering: {
+      type: Array as PropType<Clustering>,
+      required: true,
+    },
 
-  getClusterElements = getClusterElements
+    selectedNode: {
+      type: Object as PropType<File>,
+      required: false,
+    },
 
-  getAverageClusterSimilarity = getAverageClusterSimilarity
+    selectedCluster: {
+      type: Set as PropType<Cluster>,
+      required: false,
+    },
+  },
 
-  DateTime = DateTime
+  setup(props) {
+    const vuetify = useVuetify();
+    const router = useRouter();
+    const { clusterFilesSet, clusterAverageSimilarity } =
+      useCluster(toRef(props, "selectedCluster"));
 
-  getClusterIndex(): number {
-    const sortf = (a: Cluster, b:Cluster): number => getClusterElements(b).size - getClusterElements(a).size;
-    const sortedClustering = Array.from(this.currentClustering).sort(sortf);
-    return sortedClustering.indexOf(this.selectedCluster!);
-  }
+    // Timestamp of the selected node.
+    const selectedNodeTimestamp = computed(() => {
+      if (props.selectedNode?.extra.timestamp) {
+        return DateTime.fromJSDate(
+          props.selectedNode.extra.timestamp
+        ).toLocaleString(DateTime.DATETIME_MED);
+      }
+      return null;
+    });
 
-  goToInfo():void {
-    this.$router.replace("#");
-    this.$router.replace(`#${this.getClusterIndex()}`);
-  }
-}
+    // index of the selected cluster.
+    const selectedClusterIndex = computed(() => {
+      if (!props.selectedCluster) return 0;
+
+      const sortFn = (a: Cluster, b:Cluster): number => getClusterElements(b).size - getClusterElements(a).size;
+      const sortedClustering = Array.from(props.currentClustering).sort(sortFn);
+      return sortedClustering.indexOf(props.selectedCluster);
+    });
+
+    // Go to the information section of this cluster.
+    const goToInfo = (): void => {
+      const clusterHash = `#clustering-card-${selectedClusterIndex.value}`;
+      // Navigate to the cluster card.
+      // The hash will be used by the clustering table to expand the correct cluster.
+      router.replace("#");
+      router.replace(clusterHash);
+
+      // Scroll to the cluster card.
+      vuetify.goTo(clusterHash);
+    };
+
+    return {
+      clusterFilesSet,
+      clusterAverageSimilarity,
+      selectedNodeTimestamp,
+      goToInfo,
+    };
+  },
+});
 </script>
-<style>
+
+<style scoped>
 .selected-info {
   max-width: 350px;
   position: absolute;
-  z-index: 5;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .namecontainer {

--- a/web/src/util/Types.ts
+++ b/web/src/util/Types.ts
@@ -1,1 +1,4 @@
+import { Ref } from "@vue/composition-api";
+
 export type SortingFunction<T> = (a: T, b:T) => number;
+export type MaybeRef<T> = T | Ref<T>;

--- a/web/src/views/FileAnalysis.vue
+++ b/web/src/views/FileAnalysis.vue
@@ -5,15 +5,14 @@
   </div>
 </template>
 <script lang="ts">
-import { Component } from "vue-property-decorator";
-import DataView from "@/views/DataView";
+import { defineComponent } from "@vue/composition-api";
 import SummaryCard from "@/components/summary/SummaryCard.vue";
 import SummaryList from "@/components/summary/SummaryList.vue";
 
-@Component({
-  components: { SummaryCard, SummaryList }
-})
-export default class FileAnalysis extends DataView {
-
-}
+export default defineComponent({
+  components: {
+    SummaryCard,
+    SummaryList
+  }
+});
 </script>

--- a/web/src/views/GraphView.vue
+++ b/web/src/views/GraphView.vue
@@ -3,14 +3,14 @@
     <v-row style="height: 100vh">
       <v-col cols="12" class="no-y-padding">
         <Graph
-          :files="files"
-          :pairs="pairs"
-          :cutoff="cutoff"
           :showSingletons="showSingletons"
           :legend="legend"
           :clustering="clustering"
+          :files="filesList"
+          :pairs="pairsList"
           :zoomTo="'#clustering-table'"
           :selected-node="selectedNode"
+          polygon
           @selectedNodeInfo="setSelectedNode"
           @selectedClusterInfo="setSelectedCluster"
         >
@@ -54,6 +54,7 @@
     <v-row>
       <v-col cols="11">
         <ClusteringTable
+          v-if="false"
           :current-clustering="clustering"
           :selected-cluster="selectedCluster"
         />
@@ -78,8 +79,8 @@ export default defineComponent({
   setup() {
     const route = useRoute();
     const { cutoff } = storeToRefs(useApiStore());
-    const { files, filesList } = storeToRefs(useFileStore());
-    const { pairs } = storeToRefs(usePairStore());
+    const { filesList } = storeToRefs(useFileStore());
+    const { pairsList } = storeToRefs(usePairStore());
 
     // Show singletons in the graph.
     const showSingletons = ref(false);
@@ -119,9 +120,8 @@ export default defineComponent({
 
     return {
       cutoff,
-      files,
       filesList,
-      pairs,
+      pairsList,
       showSingletons,
       legend,
       selectedNode,

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -19,7 +19,8 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
+    "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
+    "skipLibCheck": true,
   },
   "include": [
     "src/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,6 +2153,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/web-bluetooth@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.14.tgz#94e175b53623384bff1f354cdb3197a8d63cdbe5"
+  integrity sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A==
+
 "@types/webpack-dev-server@^3", "@types/webpack-dev-server@^3.11.0":
   version "3.11.6"
   resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.11.6.tgz#d8888cfd2f0630203e13d3ed7833a4d11b8a34dc"
@@ -2866,6 +2871,28 @@
     "@types/markdown-it" "^10.0.0"
     "@types/webpack-dev-server" "^3"
     webpack-chain "^6.0.0"
+
+"@vueuse/core@^8.7.5":
+  version "8.7.5"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-8.7.5.tgz#e74a888251ea11a9d432068ce18cbdfc4f810251"
+  integrity sha512-tqgzeZGoZcXzoit4kOGLWJibDMLp0vdm6ZO41SSUQhkhtrPhAg6dbIEPiahhUu6sZAmSYvVrZgEr5aKD51nrLA==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.14"
+    "@vueuse/metadata" "8.7.5"
+    "@vueuse/shared" "8.7.5"
+    vue-demi "*"
+
+"@vueuse/metadata@8.7.5":
+  version "8.7.5"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-8.7.5.tgz#c7f2b21d873d1604a8860ed9c5728d8f3295f00a"
+  integrity sha512-emJZKRQSaEnVqmlu39NpNp8iaW+bPC2kWykWoWOZMSlO/0QVEmO/rt8A5VhOEJTKLX3vwTevqbiRy9WJRwVOQg==
+
+"@vueuse/shared@8.7.5":
+  version "8.7.5"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-8.7.5.tgz#06fb08f6f8fc9e90be9d1e033fa443de927172b0"
+  integrity sha512-THXPvMBFmg6Gf6AwRn/EdTh2mhqwjGsB2Yfp374LNQSQVKRHtnJ0I42bsZTn7nuEliBxqUrGQm/lN6qUHmhJLw==
+  dependencies:
+    vue-demi "*"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
* Refactor the D3 Graph component to the Composition API
* Install `@vueuse/core` for helper composables
* Temporary disable typechecks on dependencies.
  * This is necessary as `@vueuse/core` requires a higher TypeScript version and upgrading the current TypeScript version is not possible due to some outdated dependencies.

There is still room for performance improvements in the graph (debouncing data, optimising specific function calls, ...) but these will be done in a future PR.
There are also some types that must be created instead of using `any`, but I recommendend we tackle this once we upgrade to the ESM version of D3 with better type support.