### PR TITLE
Run demo analysis with --semantic flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,15 +140,15 @@ jobs:
       - name: Run analysis on samples
         run: |
           cd analysis
-          dolos -l javascript -f csv -o samples-results samples/*.js
+          dolos -l javascript -f csv --semantic -o samples-results samples/*.js
       - name: Run analysis on Java files
         run: |
           cd analysis
-          dolos -l java -f csv -o java-results java-labels.csv
+          dolos -l java -f csv -o java-results --semantic java-labels.csv
       - name: Run analysis on C files
         run: |
           cd analysis
-          dolos -l c -f csv -o c-results c-labels.csv
+          dolos -l c -f csv -o c-results --semantic c-labels.csv
       - name: Deploy results to demo site
         run: |
           cd analysis

--- a/yarn.lock
+++ b/yarn.lock
@@ -4187,6 +4187,13 @@ busboy@^0.3.1:
   dependencies:
     dicer "0.3.0"
 
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -7247,12 +7254,12 @@ expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-express-fileupload@^1.2.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/express-fileupload/-/express-fileupload-1.3.1.tgz#3238472def305b8cb4cc5936a953761d0c442011"
-  integrity sha512-LD1yabD3exmWIFujKGDnT1rmxSomaqQSlUvzIsrA1ZgwCJ6ci7lg2YHFGM3Q6DfK+Yk0gAVU7GWLE7qDMwZLkw==
+express-fileupload@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/express-fileupload/-/express-fileupload-1.4.0.tgz#be9d70a881d6c2b1ce668df86e4f89ddbf238ec7"
+  integrity sha512-RjzLCHxkv3umDeZKeFeMg8w7qe0V09w3B7oGZprr/oO2H/ISCgNzuqzn7gV3HRWb37GjRk429CCpSLS2KNTqMQ==
   dependencies:
-    busboy "^0.3.1"
+    busboy "^1.6.0"
 
 express-history-api-fallback@^2.2.1:
   version "2.2.1"
@@ -13739,6 +13746,11 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Since #726, we can perform a semantic analysis. This PR changes the GitHub actions to enable this analysis when analyzing the demo files.