### PR TITLE
Improve performance & fix graph bugs

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -109,17 +109,15 @@
 
     <v-main>
       <v-container class="container">
-        <keep-alive>
-          <router-view v-if="isLoaded" />
-          <loading v-else />
-        </keep-alive>
+        <router-view v-if="isLoaded" />
+        <loading v-else />
       </v-container>
     </v-main>
   </v-app>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed } from "@vue/composition-api";
+import { defineComponent, shallowRef, computed } from "@vue/composition-api";
 import { storeToRefs } from "pinia";
 import { useRouter, useBreakpoints } from "@/composables";
 import { useApiStore } from "@/api/stores";
@@ -134,7 +132,7 @@ export default defineComponent({
     const { isLoaded, isAnonymous } = storeToRefs(api);
 
     // If the drawer is open/closed.
-    const drawer = ref(breakpoints.value.desktop);
+    const drawer = shallowRef(breakpoints.value.desktop);
 
     // Current version of the application.
     const version = computed(() => packageJson.version);

--- a/web/src/api/stores/api.store.ts
+++ b/web/src/api/stores/api.store.ts
@@ -41,7 +41,7 @@ export const useApiStore = defineStore("api", () => {
     await semanticStore.hydrate();
 
     // Calculate the initial cut-off value.
-    cutoff.value = getInterpolatedSimilarity(Object.values(pairStore.pairs));
+    cutoff.value = getInterpolatedSimilarity(pairStore.pairsList);
 
     isLoaded.value = true;
   };

--- a/web/src/api/stores/api.store.ts
+++ b/web/src/api/stores/api.store.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref, watch } from "@vue/composition-api";
+import { shallowRef, watch } from "@vue/composition-api";
 import { getInterpolatedSimilarity } from "@/api/utils";
 import {
   useFileStore,
@@ -21,13 +21,13 @@ export const useApiStore = defineStore("api", () => {
   const semanticStore = useSemanticStore();
 
   // If the data is loaded.
-  const isLoaded = ref(false);
+  const isLoaded = shallowRef(false);
 
   // Whether the names should be anonymized.
-  const isAnonymous = ref(false);
+  const isAnonymous = shallowRef(false);
 
   // Cut-off value.
-  const cutoff = ref(0.75);
+  const cutoff = shallowRef(0.75);
 
   // Hydrate the API stores.
   const hydrate = async (): Promise<void> => {

--- a/web/src/api/stores/api.store.ts
+++ b/web/src/api/stores/api.store.ts
@@ -29,7 +29,7 @@ export const useApiStore = defineStore("api", () => {
 
   // Cut-off value.
   const cutoff = shallowRef(0.75);
-  const cutoffDebounced = refDebounced(cutoff, 150);
+  const cutoffDebounced = refDebounced(cutoff, 100);
 
   // Hydrate the API stores.
   const hydrate = async (): Promise<void> => {

--- a/web/src/api/stores/api.store.ts
+++ b/web/src/api/stores/api.store.ts
@@ -8,6 +8,7 @@ import {
   usePairStore,
   useSemanticStore,
 } from "@/api/stores";
+import { refDebounced } from "@vueuse/shared";
 
 /**
  * Store managing the API.
@@ -28,6 +29,7 @@ export const useApiStore = defineStore("api", () => {
 
   // Cut-off value.
   const cutoff = shallowRef(0.75);
+  const cutoffDebounced = refDebounced(cutoff, 150);
 
   // Hydrate the API stores.
   const hydrate = async (): Promise<void> => {
@@ -58,6 +60,7 @@ export const useApiStore = defineStore("api", () => {
     isAnonymous,
     isLoaded,
     cutoff,
+    cutoffDebounced,
     hydrate,
   };
 });

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { ref, computed } from "@vue/composition-api";
+import { shallowRef, computed } from "@vue/composition-api";
 import { DATA_URL } from "@/api";
 import { File, ObjMap } from "@/api/models";
 import { useApiStore } from "@/api/stores";
@@ -11,11 +11,11 @@ import { colors, names, uniqueNamesGenerator } from "unique-names-generator";
  */
 export const useFileStore = defineStore("files", () => {
   // List of files.
-  const files = ref<ObjMap<File>>({});
+  const files = shallowRef<ObjMap<File>>({});
   const filesList = computed<File[]>(() => Object.values(files.value));
 
   // If this store has been hydrated.
-  const hydrated = ref(false);
+  const hydrated = shallowRef(false);
 
   // Legend of files.
   const legend = computed(() => {

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -5,6 +5,7 @@ import { DATA_URL } from "@/api";
 import { File, ObjMap } from "@/api/models";
 import { useApiStore } from "@/api/stores";
 import { colors, names, uniqueNamesGenerator } from "unique-names-generator";
+import { useLegend } from "@/composables";
 
 /**
  * Store containing the file data & helper functions.
@@ -18,25 +19,7 @@ export const useFileStore = defineStore("files", () => {
   const hydrated = shallowRef(false);
 
   // Legend of files.
-  const legend = computed(() => {
-    const labels = new Set<string>();
-
-    for (const file of filesList.value) {
-      labels.add(file.extra.labels || "N/A");
-    }
-
-    const colorScale = d3
-      .scaleOrdinal(d3.schemeCategory10.filter((c) => c !== "#7f7f7f"))
-      .domain([...labels].reverse());
-
-    const legend = [...labels].sort().map((p) => ({
-      label: p,
-      selected: true,
-      color: colorScale(p),
-    }));
-
-    return Object.fromEntries(legend.map((l) => [l.label, l]));
-  });
+  const legend = useLegend(files);
 
   // Parse the files from a CSV string.
   function parse(fileData: d3.DSVRowArray, anonymize = false): ObjMap<File> {

--- a/web/src/api/stores/kgram.store.ts
+++ b/web/src/api/stores/kgram.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { ref } from "@vue/composition-api";
+import { shallowRef } from "@vue/composition-api";
 import { DATA_URL } from "@/api";
 import { Kgram, File, ObjMap } from "@/api/models";
 import { assertType } from "@/api/utils";
@@ -11,10 +11,10 @@ import { useFileStore } from "@/api/stores";
  */
 export const useKgramStore = defineStore("kgrams", () => {
   // List of k-grams.
-  const kgrams = ref<ObjMap<Kgram>>({});
+  const kgrams = shallowRef<ObjMap<Kgram>>({});
 
   // If this store has been hydrated.
-  const hydrated = ref(false);
+  const hydrated = shallowRef(false);
 
   // Parse the k-grams from a CSV string.
   function parse(

--- a/web/src/api/stores/metadata.store.ts
+++ b/web/src/api/stores/metadata.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { ref } from "@vue/composition-api";
+import { shallowRef } from "@vue/composition-api";
 import { DATA_URL } from "@/api";
 import { Metadata } from "@/api/models";
 import { castToType } from "@/api/utils";
@@ -10,10 +10,10 @@ import { castToType } from "@/api/utils";
  */
 export const useMetadataStore = defineStore("metadata", () => {
   // Metadata.
-  const metadata = ref<Metadata>({});
+  const metadata = shallowRef<Metadata>({});
 
   // If this store has been hydrated.
-  const hydrated = ref(false);
+  const hydrated = shallowRef(false);
 
   // Parse the metadata from a CSV string.
   function parse(data: d3.DSVRowArray): Metadata {

--- a/web/src/api/stores/pair.store.ts
+++ b/web/src/api/stores/pair.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { ref, computed } from "@vue/composition-api";
+import { shallowRef, computed } from "@vue/composition-api";
 import { DATA_URL } from "@/api";
 import { assertType, fileToTokenizedFile } from "@/api/utils";
 import {
@@ -31,11 +31,11 @@ import {
  */
 export const usePairStore = defineStore("pairs", () => {
   // List of pairs.
-  const pairs = ref<ObjMap<Pair>>({});
+  const pairs = shallowRef<ObjMap<Pair>>({});
   const pairsList = computed<Pair[]>(() => Object.values(pairs.value));
 
   // If this store has been hydrated.
-  const hydrated = ref(false);
+  const hydrated = shallowRef(false);
 
   // Parse the pairs from a CSV string.
   function parse(pairData: d3.DSVRowArray, files: ObjMap<File>): ObjMap<Pair> {

--- a/web/src/api/stores/semantic.store.ts
+++ b/web/src/api/stores/semantic.store.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref, computed } from "@vue/composition-api";
+import { shallowRef, computed } from "@vue/composition-api";
 import { DATA_URL } from "@/api";
 import { Semantic, ObjMap, File } from "@/api/models";
 import { useFileStore } from "@/api/stores";
@@ -11,13 +11,13 @@ import { DecodedSemanticResult } from "@dodona/dolos-lib";
  */
 export const useSemanticStore = defineStore("semantic", () => {
   // List of occurrences.
-  const occurrences = ref<number[][]>([]);
+  const occurrences = shallowRef<number[][]>([]);
 
   // Whether the sementic data is available.
   const isSemantic = computed(() => occurrences.value.length > 0);
 
   // If this store has been hydrated.
-  const hydrated = ref(false);
+  const hydrated = shallowRef(false);
 
   // Parse the semantic data.
   function parse(semantic: Semantic, files: ObjMap<File>): number[][] {

--- a/web/src/components/ClusteringTable.vue
+++ b/web/src/components/ClusteringTable.vue
@@ -33,7 +33,7 @@
 import {
   defineComponent,
   PropType,
-  ref,
+  shallowRef,
   computed,
   watch,
 } from "@vue/composition-api";
@@ -59,7 +59,7 @@ export default defineComponent({
     const { cutoff } = storeToRefs(useApiStore());
 
     // Active expansion panel.
-    const panel = ref(-1);
+    const panel = shallowRef(-1);
 
     // Table headers
     const headers = [

--- a/web/src/components/ClusteringTable.vue
+++ b/web/src/components/ClusteringTable.vue
@@ -22,7 +22,6 @@
         v-for="(cluster, index) in sortedClustering"
         :key="index"
         :cluster="cluster"
-        :cutoff="cutoff"
         :id="`clustering-card-${index}`"
       />
     </v-expansion-panels>

--- a/web/src/components/CompareCard.vue
+++ b/web/src/components/CompareCard.vue
@@ -189,7 +189,7 @@
 import {
   defineComponent,
   PropType,
-  ref,
+  shallowRef,
   computed,
   onMounted,
   watch,
@@ -241,20 +241,20 @@ export default defineComponent({
     ];
 
     // If the files have been swapped.
-    const filesSwapped = ref(false);
+    const filesSwapped = shallowRef(false);
 
-    const fragmentListExtended = ref(false);
-    const selectedItem = ref(-1);
-    const fragmentClickCount = ref(0);
-    const currentFragmentClassIndex = ref(0);
+    const fragmentListExtended = shallowRef(false);
+    const selectedItem = shallowRef(-1);
+    const fragmentClickCount = shallowRef(0);
+    const currentFragmentClassIndex = shallowRef(0);
 
     // Maps that contain for each selection the corresponding selection on the other file.
-    const leftMap = ref<Map<SelectionId, SelectionId[]>>(new Map());
-    const rightMap = ref<Map<SelectionId, SelectionId[]>>(new Map());
-    const sideMap = ref<Map<SideID, Map<SelectionId, SelectionId[]>>>(
+    const leftMap = shallowRef<Map<SelectionId, SelectionId[]>>(new Map());
+    const rightMap = shallowRef<Map<SelectionId, SelectionId[]>>(new Map());
+    const sideMap = shallowRef<Map<SideID, Map<SelectionId, SelectionId[]>>>(
       new Map()
     );
-    const sideSelectionsToFragments = ref<{
+    const sideSelectionsToFragments = shallowRef<{
       [key in SideID]: {
         [key: string]: Fragment[];
       };
@@ -262,7 +262,7 @@ export default defineComponent({
       [SideID.leftSideId]: {},
       [SideID.rightSideId]: {},
     });
-    const lastHovered = ref<{
+    const lastHovered = shallowRef<{
       [key in SideID]: {
         fragmentClasses: Array<SelectionId>;
       };
@@ -270,7 +270,7 @@ export default defineComponent({
       [SideID.leftSideId]: { fragmentClasses: [] },
       [SideID.rightSideId]: { fragmentClasses: [] },
     });
-    const selected = ref<{
+    const selected = shallowRef<{
       sides: {
         [key in SideID]: {
           fragmentClasses: Array<SelectionId>;
@@ -285,9 +285,9 @@ export default defineComponent({
       },
     });
 
-    const leftScrollFraction = ref(0);
-    const rightScrollFraction = ref(0);
-    const linesVisible = ref(0);
+    const leftScrollFraction = shallowRef(0);
+    const rightScrollFraction = shallowRef(0);
+    const linesVisible = shallowRef(0);
 
     // Active pair of files.
     // Used to make the switch between left and right file easier.

--- a/web/src/components/CompareCard.vue
+++ b/web/src/components/CompareCard.vue
@@ -190,6 +190,7 @@ import {
   defineComponent,
   PropType,
   shallowRef,
+  ref,
   computed,
   onMounted,
   watch,
@@ -254,7 +255,7 @@ export default defineComponent({
     const sideMap = shallowRef<Map<SideID, Map<SelectionId, SelectionId[]>>>(
       new Map()
     );
-    const sideSelectionsToFragments = shallowRef<{
+    const sideSelectionsToFragments = ref<{
       [key in SideID]: {
         [key: string]: Fragment[];
       };
@@ -262,7 +263,7 @@ export default defineComponent({
       [SideID.leftSideId]: {},
       [SideID.rightSideId]: {},
     });
-    const lastHovered = shallowRef<{
+    const lastHovered = ref<{
       [key in SideID]: {
         fragmentClasses: Array<SelectionId>;
       };
@@ -270,7 +271,7 @@ export default defineComponent({
       [SideID.leftSideId]: { fragmentClasses: [] },
       [SideID.rightSideId]: { fragmentClasses: [] },
     });
-    const selected = shallowRef<{
+    const selected = ref<{
       sides: {
         [key in SideID]: {
           fragmentClasses: Array<SelectionId>;

--- a/web/src/components/FragmentList.vue
+++ b/web/src/components/FragmentList.vue
@@ -110,7 +110,7 @@ import {
   defineComponent,
   PropType,
   computed,
-  ref,
+  shallowRef,
   watch,
   onMounted,
   onUnmounted,
@@ -164,8 +164,8 @@ export default defineComponent({
       }
     ]);
 
-    const selectionsIds = ref<[SelectionId, SelectionId][]>([]);
-    const dataTableSelection = ref< [FragmentWithId] | []>([]);
+    const selectionsIds = shallowRef<[SelectionId, SelectionId][]>([]);
+    const dataTableSelection = shallowRef< [FragmentWithId] | []>([]);
 
     const fragmentLengths = computed(() => {
       const lengths = props.pair.fragments?.map(fragment => fragment.occurrences.length);

--- a/web/src/components/PairsTable.vue
+++ b/web/src/components/PairsTable.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed, ref } from "@vue/composition-api";
+import { defineComponent, PropType, computed, shallowRef } from "@vue/composition-api";
 import { useRouter, useRoute } from "@/composables";
 import { Pair, ObjMap } from "@/api/models";
 
@@ -65,7 +65,7 @@ export default defineComponent({
     };
 
     // Search value.
-    const search = ref("");
+    const search = shallowRef("");
 
     // Items in the format for the the data-table.
     const items = computed(() => {

--- a/web/src/components/clustering/ClusteringCard.vue
+++ b/web/src/components/clustering/ClusteringCard.vue
@@ -52,7 +52,7 @@
 import {
   defineComponent,
   PropType,
-  ref,
+  shallowRef,
   computed,
   toRef,
 } from "@vue/composition-api";
@@ -73,7 +73,7 @@ export default defineComponent({
   },
 
   setup(props) {
-    const activeTab = ref(1);
+    const activeTab = shallowRef(1);
     const { clusterFiles } = useCluster(toRef(props, "cluster"));
 
     // If the timeline should be shown.

--- a/web/src/components/clustering/FileTagList.vue
+++ b/web/src/components/clustering/FileTagList.vue
@@ -6,7 +6,7 @@
 import {
   defineComponent,
   PropType,
-  ref,
+  shallowRef,
   computed,
   watch,
   onMounted,
@@ -34,7 +34,7 @@ export default defineComponent({
     const { legend } = storeToRefs(useFileStore());
 
     // List template ref.
-    const listElement = ref();
+    const listElement = shallowRef();
 
     // List element size.
     const listElementSize = useElementSize(listElement);

--- a/web/src/components/clustering/GraphTab.vue
+++ b/web/src/components/clustering/GraphTab.vue
@@ -56,9 +56,9 @@ export default defineComponent({
   setup(props) {
     const { cutoff } = storeToRefs(useApiStore());
     const legend = shallowRef([]);
-    const clusterFiles = ref<File[]>([]);
-    const clusterPairs = ref<Pair[]>([]);
-    const selectedFiles = ref<File[]>([]);
+    const clusterFiles = shallowRef<File[]>([]);
+    const clusterPairs = shallowRef<Pair[]>([]);
+    const selectedFiles = shallowRef<File[]>([]);
     const selectionManager = shallowRef(new SelectionManager(1));
 
     // Clustering.

--- a/web/src/components/clustering/GraphTab.vue
+++ b/web/src/components/clustering/GraphTab.vue
@@ -31,6 +31,7 @@ import {
   defineComponent,
   PropType,
   ref,
+  shallowRef,
   onMounted,
 } from "@vue/composition-api";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
@@ -54,11 +55,11 @@ export default defineComponent({
 
   setup(props) {
     const { cutoff } = storeToRefs(useApiStore());
-    const legend = ref([]);
+    const legend = shallowRef([]);
     const clusterFiles = ref<File[]>([]);
     const clusterPairs = ref<Pair[]>([]);
     const selectedFiles = ref<File[]>([]);
-    const selectionManager = ref(new SelectionManager(1));
+    const selectionManager = shallowRef(new SelectionManager(1));
 
     // Clustering.
     const clustering = useClustering();

--- a/web/src/components/clustering/GraphTab.vue
+++ b/web/src/components/clustering/GraphTab.vue
@@ -3,7 +3,6 @@
     <Graph
       :pairs="clusterPairs"
       :files="clusterFiles"
-      :cutoff="cutoff"
       :legend="legend"
       :polygon="false"
       :clustering="clustering"

--- a/web/src/components/clustering/HeatMap.vue
+++ b/web/src/components/clustering/HeatMap.vue
@@ -55,7 +55,7 @@
 import {
   defineComponent,
   PropType,
-  ref,
+  shallowRef,
   computed,
   watch,
   onMounted,
@@ -86,14 +86,14 @@ export default defineComponent({
     const router = useRouter();
 
     // List of selected files.
-    const selectedFiles = ref<File[]>([]);
+    const selectedFiles = shallowRef<File[]>([]);
 
     // Pair that is being hovered in the heatmap.
-    const hoveredPair = ref<Pair | null>(null);
+    const hoveredPair = shallowRef<Pair | null>(null);
 
     // Heatmap element & legend template ref.
-    const heatmapElement = ref<SVGSVGElement>();
-    const heatmapLegendElement = ref<SVGSVGElement>();
+    const heatmapElement = shallowRef<SVGSVGElement>();
+    const heatmapLegendElement = shallowRef<SVGSVGElement>();
 
     // Heatmap element size
     const { width, height } = {

--- a/web/src/components/clustering/HeatMap.vue
+++ b/web/src/components/clustering/HeatMap.vue
@@ -80,7 +80,7 @@ export default defineComponent({
 
   setup(props) {
     const { files } = storeToRefs(useFileStore());
-    const { cutoff } = storeToRefs(useApiStore());
+    const { cutoff, cutoffDebounced } = storeToRefs(useApiStore());
     const { pairsList } = storeToRefs(usePairStore());
     const { clusterFiles } = useCluster(toRef(props, "cluster"));
     const router = useRouter();
@@ -283,7 +283,7 @@ export default defineComponent({
 
     // Redraw the heatmap when the cluster changes.
     watch(
-      () => cutoff.value,
+      () => cutoffDebounced.value,
       () => {
         draw();
       }

--- a/web/src/components/clustering/TimeSeries.vue
+++ b/web/src/components/clustering/TimeSeries.vue
@@ -35,7 +35,7 @@ export default defineComponent({
 
   setup(props, { emit }) {
     const { clusterFiles } = useCluster(toRef(props, "cluster"));
-    const { cutoff } = storeToRefs(useApiStore());
+    const { cutoffDebounced } = storeToRefs(useApiStore());
     const legend = shallowRef<Legend>();
 
     // Timeseries element size
@@ -153,7 +153,7 @@ export default defineComponent({
 
     // Redraw the timeseries when the cluster changes.
     watch(
-      () => [cutoff.value, legend.value],
+      () => [cutoffDebounced.value, legend.value],
       () => {
         draw();
       }

--- a/web/src/components/clustering/TimeSeries.vue
+++ b/web/src/components/clustering/TimeSeries.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, watch, toRef, onMounted } from "@vue/composition-api";
+import { defineComponent, PropType, ref, shallowRef, watch, toRef, onMounted } from "@vue/composition-api";
 import { storeToRefs } from "pinia";
 import { useApiStore } from "@/api/stores";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
@@ -51,7 +51,7 @@ export default defineComponent({
     };
 
     // Timeseries template ref.
-    const timeseriesElement = ref();
+    const timeseriesElement = shallowRef();
 
     // Timeseries D3
     const timeseries = d3

--- a/web/src/components/clustering/TimeSeries.vue
+++ b/web/src/components/clustering/TimeSeries.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, shallowRef, watch, toRef, onMounted } from "@vue/composition-api";
+import { defineComponent, PropType, shallowRef, watch, toRef, onMounted } from "@vue/composition-api";
 import { storeToRefs } from "pinia";
 import { useApiStore } from "@/api/stores";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
@@ -36,7 +36,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const { clusterFiles } = useCluster(toRef(props, "cluster"));
     const { cutoff } = storeToRefs(useApiStore());
-    const legend = ref<Legend>();
+    const legend = shallowRef<Legend>();
 
     // Timeseries element size
     const margin = {

--- a/web/src/components/clustering/TimeSeriesCard.vue
+++ b/web/src/components/clustering/TimeSeriesCard.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref } from "@vue/composition-api";
+import { defineComponent, PropType, ref, shallowRef } from "@vue/composition-api";
 import { File } from "@/api/models";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
 import TimeSeriesDiagram from "@/components/clustering/TimeSeries.vue";
@@ -59,7 +59,7 @@ export default defineComponent({
 
   setup() {
     const files = ref<File[]>([]);
-    const show = ref(true);
+    const show = shallowRef(true);
 
     const setNewFiles = (list: File[]): void => {
       show.value = list.every((f) => f.extra.timestamp);

--- a/web/src/components/clustering/TimeSeriesCard.vue
+++ b/web/src/components/clustering/TimeSeriesCard.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, shallowRef } from "@vue/composition-api";
+import { defineComponent, PropType, shallowRef } from "@vue/composition-api";
 import { File } from "@/api/models";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
 import TimeSeriesDiagram from "@/components/clustering/TimeSeries.vue";
@@ -58,7 +58,7 @@ export default defineComponent({
   },
 
   setup() {
-    const files = ref<File[]>([]);
+    const files = shallowRef<File[]>([]);
     const show = shallowRef(true);
 
     const setNewFiles = (list: File[]): void => {

--- a/web/src/components/graph/Graph.vue
+++ b/web/src/components/graph/Graph.vue
@@ -73,7 +73,7 @@ export default defineComponent({
     const { cutoff } = storeToRefs(useApiStore());
 
     // Reference to the container element.
-    const container = ref<HTMLElement>();
+    const container = shallowRef<HTMLElement>();
     // Container size
     const { width, height } = useElementSize(container);
 

--- a/web/src/components/graph/Graph.vue
+++ b/web/src/components/graph/Graph.vue
@@ -70,7 +70,7 @@ export default defineComponent({
   },
 
   setup(props, { emit }) {
-    const { cutoff } = storeToRefs(useApiStore());
+    const { cutoff, cutoffDebounced } = storeToRefs(useApiStore());
 
     // Reference to the container element.
     const container = shallowRef<HTMLElement>();
@@ -316,7 +316,7 @@ export default defineComponent({
 
     // Update the graph when the data changes.
     watch(
-      () => [cutoff.value, props.showSingletons, props.legend],
+      () => [cutoffDebounced.value, props.showSingletons, props.legend],
       () => updateGraph()
     );
 

--- a/web/src/components/graph/Graph.vue
+++ b/web/src/components/graph/Graph.vue
@@ -6,7 +6,16 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, computed, watch, onMounted, onUnmounted } from "@vue/composition-api";
+import {
+  defineComponent,
+  PropType,
+  ref,
+  shallowRef,
+  computed,
+  watch,
+  onMounted,
+  onUnmounted,
+} from "@vue/composition-api";
 import { useApiStore } from "@/api/stores";
 import { Pair, File } from "@/api/models";
 import { useCluster } from "@/composables";
@@ -69,7 +78,7 @@ export default defineComponent({
     const { width, height } = useElementSize(container);
 
     // Selected cluser
-    const selectedCluster = ref<Cluster | null>(null);
+    const selectedCluster = shallowRef<Cluster | null>(null);
     const selectedClusterMeta = useCluster(selectedCluster);
 
     // Map of nodes (files) in the graph.
@@ -102,10 +111,10 @@ export default defineComponent({
     });
 
     // List of edges to display in the graph.
-    const edges = ref();
+    const edges = shallowRef();
 
     // List of node to display in the graph.
-    const nodes = ref();
+    const nodes = shallowRef();
 
     // Cluster colors
     const clusterColors = computed(() => {
@@ -138,18 +147,18 @@ export default defineComponent({
     const graphContainer = graph.append("g");
 
     // If the graph has been rendered the first time.
-    const graphInitialized = ref(false);
+    const graphInitialized = shallowRef(false);
 
     // Edges between nodes in the graph.
     const graphEdgesBase = graphContainer.append("g");
-    const graphEdges = ref();
+    const graphEdges = shallowRef();
 
     // Nodes in the graph.
     const graphNodesBase = graphContainer.append("g");
-    const graphNodes = ref();
+    const graphNodes = shallowRef();
 
     // Convex hull tool for creating hulls around clusters.
-    const graphHullTool = ref();
+    const graphHullTool = shallowRef();
 
     // Add a marker to the graph for showing the direction of the edges.
     graph

--- a/web/src/components/graph/Graph.vue
+++ b/web/src/components/graph/Graph.vue
@@ -90,8 +90,6 @@ export default defineComponent({
       const nodesMap = new Map<number, any>();
       for (const file of props.files) {
         const label = file.extra.labels ?? "N/A";
-        const labels = props.legend as any;
-        const visible = labels[label] ? labels[label].selected : true;
 
         nodesMap.set(file.id, {
           id: file.id,
@@ -103,12 +101,17 @@ export default defineComponent({
           neighbors: [],
           edges: [],
           label,
-          visible,
         });
       }
 
       return nodesMap;
     });
+
+    // Get if a node is visible or not.
+    const isVisible = (node: any): boolean => {
+      const labels = props.legend ?? {};
+      return labels[node.label] ? labels[node.label].selected : true;
+    };
 
     // List of edges to display in the graph.
     const edges = shallowRef();
@@ -217,7 +220,7 @@ export default defineComponent({
         .filter(pair => {
           const left = nodesMap.value.get(pair.leftFile.id);
           const right = nodesMap.value.get(pair.rightFile.id);
-          return left.visible && right.visible;
+          return isVisible(left) && isVisible(right);
         })
         // Map the pair to an edge object.
         .map(pair => {
@@ -263,10 +266,10 @@ export default defineComponent({
 
     // Calculate the nodes of the graph.
     const calculateNodes = (): any[] => {
-      const labels = props.legend as any[];
+      const labels = props.legend;
       const nodesList = Array.from(nodesMap.value.values())
         // Only display the nodes that are visible.
-        .filter(node => node.visible)
+        .filter(node => isVisible(node))
         // Only display the nodes that have neighbors.
         // Unless singletons are enabled.
         .filter(node => node.neighbors.length > 0 || props.showSingletons);

--- a/web/src/components/overview/OverviewBarchart.vue
+++ b/web/src/components/overview/OverviewBarchart.vue
@@ -7,6 +7,7 @@ import {
   defineComponent,
   PropType,
   ref,
+  shallowRef,
   computed,
   watch,
   onMounted,
@@ -56,7 +57,7 @@ export default defineComponent({
     };
 
     // Barchart template ref.
-    const barchartElement = ref();
+    const barchartElement = shallowRef();
 
     // Barchart element size
     const margin = {
@@ -76,8 +77,8 @@ export default defineComponent({
       .append("g")
       .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
-    const barchartXScale = ref();
-    const barchartYScale = ref();
+    const barchartXScale = shallowRef();
+    const barchartYScale = shallowRef();
 
     // Draw the barchart.
     const draw = (): void => {

--- a/web/src/components/summary/FileCard.vue
+++ b/web/src/components/summary/FileCard.vue
@@ -178,7 +178,7 @@ import {
   defineComponent,
   PropType,
   computed,
-  ref,
+  shallowRef,
   watch,
 } from "@vue/composition-api";
 import {
@@ -211,7 +211,7 @@ export default defineComponent({
     const { isSemantic } = storeToRefs(useSemanticStore());
 
     // Selected tab
-    const tab = ref<string>("");
+    const tab = shallowRef<string>("");
 
     // Determine the best tab based on the field with the largest score.
     const bestTab = computed(() => {

--- a/web/src/components/summary/PairStatHistogram.vue
+++ b/web/src/components/summary/PairStatHistogram.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, shallowRef, computed, watch, onMounted } from "@vue/composition-api";
+import { defineComponent, PropType, shallowRef, computed, watch, onMounted } from "@vue/composition-api";
 import { TooltipTool } from "@/d3-tools/TooltipTool";
 import { FileScoring } from "@/util/FileInterestingness";
 import { useElementSize } from "@vueuse/core";

--- a/web/src/components/summary/PairStatHistogram.vue
+++ b/web/src/components/summary/PairStatHistogram.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, computed, watch, onMounted } from "@vue/composition-api";
+import { defineComponent, PropType, ref, shallowRef, computed, watch, onMounted } from "@vue/composition-api";
 import { TooltipTool } from "@/d3-tools/TooltipTool";
 import { FileScoring } from "@/util/FileInterestingness";
 import { useElementSize } from "@vueuse/core";
@@ -66,7 +66,7 @@ export default defineComponent({
     };
 
     // Histogram template ref.
-    const histogramElement = ref();
+    const histogramElement = shallowRef();
 
     // Histogram element size
     const margin = {
@@ -85,8 +85,8 @@ export default defineComponent({
       .append("g")
       .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
-    const histogramXScale = ref();
-    const histogramYScale = ref();
+    const histogramXScale = shallowRef();
+    const histogramYScale = shallowRef();
 
     // Draw the histogram.
     const draw = (): void => {

--- a/web/src/components/summary/SummaryList.vue
+++ b/web/src/components/summary/SummaryList.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, watch } from "@vue/composition-api";
+import { defineComponent, ref, shallowRef, computed, watch } from "@vue/composition-api";
 import { storeToRefs } from "pinia";
 import { Pair } from "@/api/models";
 import { useFileStore, usePairStore } from "@/api/stores";
@@ -101,15 +101,15 @@ export default defineComponent({
     ];
 
     // Selected sorting option
-    const selectedSortOption = ref(sortOptions[0]);
+    const selectedSortOption = shallowRef(sortOptions[0]);
 
     // Pagination.
-    const page = ref(1);
+    const page = shallowRef(1);
     const pageTotal = computed(() => Math.ceil(scoredFilesSearch.value.length / 10));
     const pageAmount = 5;
 
     // Search filter.
-    const search = ref("");
+    const search = shallowRef("");
 
     // Calculator class for determining the score of a file.
     const scoringCalculator = new FileInterestingnessCalculator(pairsList.value);

--- a/web/src/components/summary/SummaryList.vue
+++ b/web/src/components/summary/SummaryList.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, shallowRef, computed, watch } from "@vue/composition-api";
+import { defineComponent, shallowRef, computed, watch } from "@vue/composition-api";
 import { storeToRefs } from "pinia";
 import { Pair } from "@/api/models";
 import { useFileStore, usePairStore } from "@/api/stores";
@@ -120,7 +120,7 @@ export default defineComponent({
     );
 
     // Scored files, after sorting.
-    const scoredFilesSorted = ref<FileScoring[]>([]);
+    const scoredFilesSorted = shallowRef<FileScoring[]>([]);
 
     // Scored files, after search filter.
     const scoredFilesSearch = computed(() =>

--- a/web/src/components/summary/SummaryVisualisation.vue
+++ b/web/src/components/summary/SummaryVisualisation.vue
@@ -40,7 +40,7 @@
 import {
   defineComponent,
   PropType,
-  ref,
+  shallowRef,
   watch,
   onMounted,
 } from "@vue/composition-api";
@@ -64,8 +64,8 @@ export default defineComponent({
   },
 
   setup(props) {
-    const currentFiles = ref<{ leftFile: File; rightFile: File } | null>(null);
-    const match = ref<PairedSemanticGroups<DecodedSemanticResult>>();
+    const currentFiles = shallowRef<{ leftFile: File; rightFile: File } | null>(null);
+    const match = shallowRef<PairedSemanticGroups<DecodedSemanticResult>>();
 
     const getPairedMatch = (): void => {
       const node = props.file.semanticMatchScore;

--- a/web/src/composables/useClustering.ts
+++ b/web/src/composables/useClustering.ts
@@ -11,5 +11,5 @@ export function useClustering(): ComputedRef<Clustering> {
   const pairStore = usePairStore();
   const fileStore = useFileStore();
 
-  return computed(() => singleLinkageCluster(pairStore.pairs, fileStore.files, apiStore.cutoff));
+  return computed(() => singleLinkageCluster(pairStore.pairs, fileStore.files, apiStore.cutoffDebounced));
 }

--- a/web/src/composables/useLegend.ts
+++ b/web/src/composables/useLegend.ts
@@ -2,6 +2,7 @@ import * as d3 from "d3";
 import { ComputedRef, computed, unref } from "@vue/composition-api";
 import { MaybeRef } from "@/util/Types";
 import { File, ObjMap } from "@/api/models";
+import { useFileStore } from "@/api/stores";
 
 export type Legend = {
   [key: string]: { label: string; selected: boolean; color: string };
@@ -11,16 +12,24 @@ export type Legend = {
  * Create a legend for the given files.
  */
 export function useLegend(files: MaybeRef<ObjMap<File> | null | undefined>): ComputedRef<Legend> {
-  return computed((): Legend => {
-    const labels = new Set<string>();
+  const fileStore = useFileStore();
 
+  return computed((): Legend => {
+    // Labels for the given files.
+    const labels = new Set<string>();
     for (const file of Object.values(unref(files) ?? [])) {
       labels.add(file.extra.labels || "N/A");
     }
 
+    // Labels for all the available files.
+    const allLabels = new Set<string>();
+    for (const file of fileStore.filesList) {
+      allLabels.add(file.extra.labels || "N/A");
+    }
+
     const colorScale = d3
       .scaleOrdinal(d3.schemeCategory10.filter((c) => c !== "#7f7f7f"))
-      .domain([...labels].reverse());
+      .domain([...allLabels].reverse());
 
     const legend = [...labels].sort().map((p) => ({
       label: p,

--- a/web/src/composables/useLegend.ts
+++ b/web/src/composables/useLegend.ts
@@ -1,21 +1,20 @@
 import * as d3 from "d3";
-import { ComputedRef, computed } from "@vue/composition-api";
-import { useFileStore } from "@/api/stores";
+import { ComputedRef, computed, unref } from "@vue/composition-api";
+import { MaybeRef } from "@/util/Types";
+import { File, ObjMap } from "@/api/models";
 
 export type Legend = {
   [key: string]: { label: string; selected: boolean; color: string };
 };
 
 /**
- * Create a legend for the available files.
+ * Create a legend for the given files.
  */
-export function useLegend(): ComputedRef<Legend> {
-  const fileStore = useFileStore();
-
+export function useLegend(files: MaybeRef<ObjMap<File> | null | undefined>): ComputedRef<Legend> {
   return computed((): Legend => {
     const labels = new Set<string>();
 
-    for (const file of Object.values(fileStore.files)) {
+    for (const file of Object.values(unref(files) ?? [])) {
       labels.add(file.extra.labels || "N/A");
     }
 

--- a/web/src/d3-tools/GraphLegend.vue
+++ b/web/src/d3-tools/GraphLegend.vue
@@ -1,65 +1,52 @@
 <template>
   <ul v-if="Object.values(legend).length > 1" class="legend">
     <li
-      v-for="legendDatum of Object.values(legend).sort()"
+      v-for="legendDatum of Object.values(legendValue).sort()"
       :key="legendDatum.label"
     >
-      <label
-        ><input
+      <label>
+        <input
           type="checkbox"
           v-model="legendDatum.selected"
           class="legend-checkbox"
           @change="onCheckChange"
         />
-        <span class="legend-label"
-          ><span
+        <span class="legend-label">
+          <span
             class="legend-color"
             :style="{
               'background-color': legendDatum.color,
             }"
-          ></span>
+          />
           {{ legendDatum.label }}
-        </span></label
-      >
+        </span>
+      </label>
     </li>
   </ul>
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, shallowRef, onMounted } from "@vue/composition-api";
+import { defineComponent, PropType } from "@vue/composition-api";
 import { File, Legend } from "@/api/models";
-import { useFileStore } from "@/api/stores";
+import { useVModel } from "@vueuse/core";
 
 export default defineComponent({
   props: {
-    currentFiles: {
-      type: Array as PropType<File[]>,
-      required: true
+    legend: {
+      type: Object as PropType<Legend>,
+      required: true,
     },
   },
 
   setup(props, { emit }) {
-    const fileStore = useFileStore();
-    const legend = shallowRef<Legend>({});
-
-    const init = (): void => {
-      const fullLegend = fileStore.legend;
-      const partLegend: Legend = {};
-      for (const key of new Set(props.currentFiles.map(cf => cf.extra.labels)).values()) {
-        if (key) { partLegend[key] = fullLegend[key]; }
-      }
-      legend.value = partLegend;
-      emit("legend", Object.assign({}, legend.value));
-    };
+    const legendValue = useVModel(props, "legend", emit);
 
     const onCheckChange = (): void => {
-      emit("legend", Object.assign({}, legend.value));
+      legendValue.value = Object.assign({}, legendValue.value);
     };
 
-    onMounted(() => init());
-
     return {
-      legend,
+      legendValue,
       onCheckChange,
     };
   }

--- a/web/src/d3-tools/GraphLegend.vue
+++ b/web/src/d3-tools/GraphLegend.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, onMounted } from "@vue/composition-api";
+import { defineComponent, PropType, shallowRef, onMounted } from "@vue/composition-api";
 import { File, Legend } from "@/api/models";
 import { useFileStore } from "@/api/stores";
 
@@ -40,7 +40,7 @@ export default defineComponent({
 
   setup(props, { emit }) {
     const fileStore = useFileStore();
-    const legend = ref<Legend>({});
+    const legend = shallowRef<Legend>({});
 
     const init = (): void => {
       const fullLegend = fileStore.legend;

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -9,7 +9,6 @@ import "roboto-fontface/css/roboto/roboto-fontface.css";
 import "@mdi/font/css/materialdesignicons.css";
 
 Vue.config.productionTip = false;
-Vue.config.performance = true;
 
 Vue.use(VueCompositionAPI);
 Vue.use(PiniaVuePlugin);

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -9,6 +9,7 @@ import "roboto-fontface/css/roboto/roboto-fontface.css";
 import "@mdi/font/css/materialdesignicons.css";
 
 Vue.config.productionTip = false;
+Vue.config.performance = true;
 
 Vue.use(VueCompositionAPI);
 Vue.use(PiniaVuePlugin);

--- a/web/src/views/Compare.vue
+++ b/web/src/views/Compare.vue
@@ -24,6 +24,7 @@ import {
   defineComponent,
   PropType,
   ref,
+  shallowRef,
   computed,
   watch,
 } from "@vue/composition-api";
@@ -45,7 +46,7 @@ export default defineComponent({
     const metadataStore = useMetadataStore();
 
     // If the fragments for a pair are loaded.
-    const isLoaded = ref(false);
+    const isLoaded = shallowRef(false);
 
     // Pair to display.
     const pair = computed(() => pairStore.getPair(parseInt(props.pairId)));

--- a/web/src/views/GraphView.vue
+++ b/web/src/views/GraphView.vue
@@ -54,7 +54,6 @@
     <v-row>
       <v-col cols="11">
         <ClusteringTable
-          v-if="false"
           :current-clustering="clustering"
           :selected-cluster="selectedCluster"
         />
@@ -64,7 +63,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, shallowRef, computed } from "@vue/composition-api";
+import { defineComponent, shallowRef, computed } from "@vue/composition-api";
 import { storeToRefs } from "pinia";
 import { File } from "@/api/models";
 import { Cluster } from "@/util/Cluster";
@@ -86,13 +85,13 @@ export default defineComponent({
     const showSingletons = shallowRef(false);
 
     // Legend.
-    const legend = ref<unknown[]>([]);
+    const legend = shallowRef<unknown[]>([]);
 
     // Node in the graph that is currently selected (file).
-    const selectedNode = ref<File>();
+    const selectedNode = shallowRef<File>();
 
     // Cluster that is currently selected.
-    const selectedCluster = ref<Cluster>();
+    const selectedCluster = shallowRef<Cluster>();
 
     // Clustering
     const clustering = useClustering();

--- a/web/src/views/GraphView.vue
+++ b/web/src/views/GraphView.vue
@@ -54,6 +54,7 @@
     <v-row>
       <v-col cols="11">
         <ClusteringTable
+          v-if="false"
           :current-clustering="clustering"
           :selected-cluster="selectedCluster"
         />
@@ -63,7 +64,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed } from "@vue/composition-api";
+import { defineComponent, ref, shallowRef, computed } from "@vue/composition-api";
 import { storeToRefs } from "pinia";
 import { File } from "@/api/models";
 import { Cluster } from "@/util/Cluster";
@@ -82,7 +83,7 @@ export default defineComponent({
     const { pairsList } = storeToRefs(usePairStore());
 
     // Show singletons in the graph.
-    const showSingletons = ref(false);
+    const showSingletons = shallowRef(false);
 
     // Legend.
     const legend = ref<unknown[]>([]);

--- a/web/src/views/GraphView.vue
+++ b/web/src/views/GraphView.vue
@@ -4,7 +4,7 @@
       <v-col cols="12" class="no-y-padding">
         <Graph
           :showSingletons="showSingletons"
-          :legend="legend"
+          :legend="legendValue"
           :clustering="clustering"
           :files="filesList"
           :pairs="pairsList"
@@ -38,8 +38,7 @@
 
           <GraphLegend
             v-if="showLegend"
-            :current-files="filesList"
-            @legend="updateLegend"
+            :legend.sync="legendValue"
           />
 
           <GraphSelectedInfo
@@ -63,9 +62,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, shallowRef, computed } from "@vue/composition-api";
+import { defineComponent, ref, shallowRef, computed } from "@vue/composition-api";
 import { storeToRefs } from "pinia";
-import { File } from "@/api/models";
+import { File, Legend } from "@/api/models";
 import { Cluster } from "@/util/Cluster";
 import { useApiStore, useFileStore, usePairStore } from "@/api/stores";
 import { useRoute, useClustering } from "@/composables";
@@ -78,14 +77,14 @@ export default defineComponent({
   setup() {
     const route = useRoute();
     const { cutoff } = storeToRefs(useApiStore());
-    const { filesList } = storeToRefs(useFileStore());
+    const { filesList, legend } = storeToRefs(useFileStore());
     const { pairsList } = storeToRefs(usePairStore());
 
     // Show singletons in the graph.
     const showSingletons = shallowRef(false);
 
     // Legend.
-    const legend = shallowRef<unknown[]>([]);
+    const legendValue = ref<Legend>(legend.value);
 
     // Node in the graph that is currently selected (file).
     const selectedNode = shallowRef<File>();
@@ -101,11 +100,6 @@ export default defineComponent({
       const { ...colors } = route.value.query;
       return Array.from(Object.values(colors)).length === 0;
     });
-
-    // Update the legend.
-    const updateLegend = (newLegend: unknown[]): void => {
-      legend.value = newLegend;
-    };
 
     // Set the selected node.
     const setSelectedNode = (node: File | undefined): void => {
@@ -123,11 +117,11 @@ export default defineComponent({
       pairsList,
       showSingletons,
       legend,
+      legendValue,
       selectedNode,
       selectedCluster,
       clustering,
       showLegend,
-      updateLegend,
       setSelectedNode,
       setSelectedCluster,
     };

--- a/web/src/views/Overview.vue
+++ b/web/src/views/Overview.vue
@@ -196,7 +196,8 @@
 
 <script lang="ts">
 import { defineComponent, computed } from "@vue/composition-api";
-import { useBreakpoints, useLegend, useClustering } from "@/composables";
+import { storeToRefs } from "pinia";
+import { useBreakpoints, useClustering } from "@/composables";
 import { Pair } from "@/api/models";
 import {
   useApiStore,
@@ -214,10 +215,10 @@ export default defineComponent({
     const fileStore = useFileStore();
     const pairStore = usePairStore();
     const metadataStore = useMetadataStore();
+    const { legend } = storeToRefs(fileStore);
 
     // File legend.
-    const legend = useLegend();
-    const legendCount = computed(() => Object.keys(legend).length);
+    const legendCount = computed(() => Object.keys(legend.value).length);
 
     // Amount of files.
     const filesCount = computed(() => Object.keys(fileStore.files).length);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10780,7 +10780,7 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.12.1, nan@^2.14.0, nan@^2.14.1:
+nan@^2.12.1, nan@^2.14.0, nan@^2.14.1, nan@^2.15.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
@@ -13834,11 +13834,6 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==
-
-streamsearch@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
-  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 streamsearch@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Performance Improvements

This PR improves the performance & responsiveness of the web application.

### Data fetching & parsing

The initial data fetching & parsing has been improved:

| Before  |  After  | Improvement |
|---|---|---|
|  4868ms  | 2630ms |  45.97% faster |

This improvement is done by replacing most `ref`-values by `shallowRef`-values, which do not track changes on object properties. This is especially noticable when working with large data values.

### Graph view

The graph view does no longer render the initial ticks, when the nodes are still scattered. The calculations are still done but are not rendered by the browser. This also hides the "explosion" caused by the random scattering of nodes.

### Debounce cut-off value

The cut-off value of the similarity is now debounced by 100ms.

## Bug fixes

* Fixed issues with legend toggling not working correctly
* Fixed issue with labels having incorrect color mappings
* Fixed errors when switching to/from anonymous file names
