### PR TITLE
Display shorter file names

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -188,4 +188,8 @@ export default defineComponent({
 .container {
   max-width: 1450px !important;
 }
+
+.fill-width {
+  width: 100%;
+}
 </style>

--- a/web/src/api/models/file.ts
+++ b/web/src/api/models/file.ts
@@ -4,6 +4,7 @@ import { DecodedSemanticResult } from "@dodona/dolos-lib";
 export interface FileIndeterminate {
   id: number;
   path: string;
+  shortPath: string;
   content: string;
   astAndMappingLoaded: boolean;
   ast: string[] | string;

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -6,6 +6,7 @@ import { File, ObjMap } from "@/api/models";
 import { useApiStore } from "@/api/stores";
 import { colors, names, uniqueNamesGenerator } from "unique-names-generator";
 import { useLegend } from "@/composables";
+import { commonFilenamePrefix } from "../utils";
 
 /**
  * Store containing the file data & helper functions.
@@ -30,7 +31,7 @@ export const useFileStore = defineStore("files", () => {
     const timeOffset = Math.random() * 1000 * 60 * 60 * 24 * 20;
     let labelCounter = 1;
 
-    const files = fileData.map((row: any) => {
+    const filesMap = fileData.map((row: any) => {
       const file = row as File;
       const extra = JSON.parse(row.extra || "{}");
       extra.timestamp = extra.createdAt && new Date(extra.createdAt);
@@ -61,8 +62,16 @@ export const useFileStore = defineStore("files", () => {
 
       return [row.id, row];
     });
+    const files: File[] = Object.fromEntries(filesMap);
 
-    return Object.fromEntries(files);
+    // Find the common path in the files.
+    const commonPath = commonFilenamePrefix(Object.values(files));
+    const commonPathLength = commonPath.length;
+    for (const file of Object.values(files)) {
+      file.shortPath = file.path.substring(commonPathLength);
+    }
+
+    return files;
   }
 
   // Fetch the files from the CSV file.

--- a/web/src/api/utils/file.ts
+++ b/web/src/api/utils/file.ts
@@ -9,3 +9,22 @@ export function fileToTokenizedFile(file: File): TokenizedFile {
     throw new Error("File AST and mapping not parsed");
   }
 }
+
+/**
+ * Common filename prefix for a given list of files
+ * @param files Files
+ * @returns Common prefix for all files.
+ */
+export function commonFilenamePrefix(files: File[]): string {
+  if (files.length <= 1) return "";
+
+  let index = 0;
+  while (
+    files[0].path[index] &&
+    files.every((f) => f.path[index] === files[0].path[index])
+  ) {
+    index++;
+  }
+
+  return files[0].path.substring(0, index) ?? "";
+}

--- a/web/src/components/CompareCard.vue
+++ b/web/src/components/CompareCard.vue
@@ -5,10 +5,10 @@
       <v-col>
         <v-card>
           <!-- Header -->
-          <v-card-title class="d-flex flex-column">
+          <v-card-title class="d-flex flex-column fill-width">
             <v-row dense>
               <v-col class="text-center">
-                {{ activePair.leftFile.path }}
+                {{ activePair.leftFile.shortPath }}
               </v-col>
 
               <v-col cols="auto">
@@ -17,8 +17,8 @@
                 </v-btn>
               </v-col>
 
-              <v-col class="text-center">
-                {{ activePair.rightFile.path }}
+              <v-col cols="auto" class="text-center">
+                {{ activePair.rightFile.shortPath }}
               </v-col>
             </v-row>
 

--- a/web/src/components/PairsTable.vue
+++ b/web/src/components/PairsTable.vue
@@ -76,8 +76,8 @@ export default defineComponent({
         .filter((pair) => (params.length > 0 ? params.includes(pair.id) : true))
         .map((pair) => ({
           pair: pair,
-          left: pair.leftFile.path,
-          right: pair.rightFile.path,
+          left: pair.leftFile.shortPath,
+          right: pair.rightFile.shortPath,
           similarity: pair.similarity.toFixed(2),
           longestFragment: pair.longestFragment,
           totalOverlap: pair.totalOverlap,

--- a/web/src/components/clustering/FileTagList.vue
+++ b/web/src/components/clustering/FileTagList.vue
@@ -53,7 +53,7 @@ export default defineComponent({
     // List tooltip tool
     const listToolTipTool = new TooltipTool<File>(file => {
       if (file.extra.fullName) return file.extra.fullName;
-      return file.path.split("/").splice(-2).join("/");
+      return file.shortPath;
     });
 
     // Draw the list.
@@ -101,7 +101,7 @@ export default defineComponent({
               return file.extra.fullName[0].toUpperCase();
             }
           } else {
-            const path = file.path.split("/");
+            const path = file.shortPath;
             return path[path.length - 1][0].toUpperCase();
           }
         })

--- a/web/src/components/clustering/HeatMap.vue
+++ b/web/src/components/clustering/HeatMap.vue
@@ -160,19 +160,13 @@ export default defineComponent({
         .axisBottom(xBand)
         .tickFormat(
           (d) =>
-            `${
-              files.value[d].extra.fullName ||
-              files.value[d].path.split("/").slice(-1).join("")
-            }`
+            `${files.value[d].extra.fullName ?? files.value[d].shortPath}`
         );
       const yAxis = d3
         .axisLeft(yBand)
         .tickFormat(
           (d) =>
-            `${
-              files.value[d].extra.fullName ||
-              files.value[d].path.split("/").slice(-1).join("")
-            }`
+            `${files.value[d].extra.fullName ?? files.value[d].shortPath}`
         );
 
       // Append the axes to the heatmap.

--- a/web/src/components/summary/FileCard.vue
+++ b/web/src/components/summary/FileCard.vue
@@ -240,9 +240,7 @@ export default defineComponent({
 
     // Shorter file name for the file.
     // TODO: extract this to a composable and use on other locations (eg: filetable)
-    const fileName = computed(() =>
-      props.file.file.path.split("/").slice(-2).join("/")
-    );
+    const fileName = computed(() => props.file.file.shortPath);
 
     // Timestamp text for the selected file.
     const fileTimestamp = computed(

--- a/web/src/components/summary/FileCardScore.vue
+++ b/web/src/components/summary/FileCardScore.vue
@@ -3,12 +3,7 @@
     <div class="similarity-score-container" v-if="displaySimilarity">
       <h3>
         Biggest similarity:
-        {{
-          getOtherFile(file.similarityScore.pair)
-            .path.split("/")
-            .slice(-2)
-            .join("/")
-        }}
+        {{ getOtherFile(file.similarityScore.pair).shortPath }}
       </h3>
       <span>
         The similarity of these files is
@@ -23,12 +18,7 @@
     <div class="largest-overlap-score-container" v-if="displayTotalOverlap">
       <h3>
         Total overlap:
-        {{
-          getOtherFile(file.totalOverlapScore.pair)
-            .path.split("/")
-            .slice(-2)
-            .join("/")
-        }}
+        {{ getOtherFile(file.totalOverlapScore.pair).shortPath }}
       </h3>
       <span>
         These files have
@@ -54,12 +44,7 @@
     >
       <h3>
         Longest Fragment:
-        {{
-          getOtherFile(file.longestFragmentScore.pair)
-            .path.split("/")
-            .slice(-2)
-            .join("/")
-        }}
+        {{ getOtherFile(file.longestFragmentScore.pair).shortPath}}
       </h3>
       <span>
         These files have
@@ -78,12 +63,7 @@
     <div class="longest-fragment-score-container" v-if="displaySemantic">
       <h3>
         Semantic match:
-        {{
-          getOtherFile(file.semanticMatchScore.pair)
-            .path.split("/")
-            .slice(-2)
-            .join("/")
-        }}
+        {{ getOtherFile(file.semanticMatchScore.pair).shortPath }}
       </h3>
       <span>
         These files have part of their structure in common: they have the same

--- a/web/src/components/summary/SummaryList.vue
+++ b/web/src/components/summary/SummaryList.vue
@@ -125,7 +125,7 @@ export default defineComponent({
     // Scored files, after search filter.
     const scoredFilesSearch = computed(() =>
       scoredFilesSorted.value.filter((file) =>
-        file.file.path.toLowerCase().includes(search.value.toLowerCase())
+        file.file.shortPath.toLowerCase().includes(search.value.toLowerCase())
       )
     );
 

--- a/web/src/components/summary/SummaryVisualisation.vue
+++ b/web/src/components/summary/SummaryVisualisation.vue
@@ -2,7 +2,7 @@
   <div style="width: 100%">
     <div v-if="currentFiles" class="compare-containers">
       <div class="side-container">
-        <h3 class="fileTitle">{{ currentFiles.leftFile.path }}</h3>
+        <h3 class="fileTitle">{{ currentFiles.leftFile.shortPath }}</h3>
         <CompareSide
           :identifier="'left'"
           :file="currentFiles.leftFile"
@@ -18,7 +18,7 @@
       </div>
 
       <div class="side-container">
-        <h3 class="fileTitle">{{ currentFiles.rightFile.path }}</h3>
+        <h3 class="fileTitle">{{ currentFiles.rightFile.shortPath }}</h3>
         <CompareSide
           :identifier="'right'"
           :file="currentFiles.rightFile"

--- a/web/src/d3-tools/GraphElementList.vue
+++ b/web/src/d3-tools/GraphElementList.vue
@@ -33,7 +33,7 @@
                   <span>{{ element.extra.labels || "No label" }}</span>
                 </v-tooltip>
               </td>
-              <td>{{ element.path.split("/").slice(-2).join("/") }}</td>
+              <td>{{ element.shortPath }}</td>
               <td>
                 <v-tooltip top>
                   <template v-slot:activator="{ on, attrs }">

--- a/web/src/d3-tools/GraphSelectedInfo.vue
+++ b/web/src/d3-tools/GraphSelectedInfo.vue
@@ -31,7 +31,7 @@
           These files are present in the cluster:
           <ul>
             <li v-for="el of clusterFilesSet" :key="el.id">
-              {{ el.path.split("/").slice(-2).join("/") }}
+              {{ el.shortPath }}
             </li>
           </ul>
         </v-card-text>


### PR DESCRIPTION
Replace long file paths by shorter names by removing the common prefix from each path. The shorter path is stores as `shortPath` on the file object.

| Before | After | 
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/6013068/176884838-f7db1486-d53c-40bb-8e6e-7a2ad3b36c6a.png) | ![image](https://user-images.githubusercontent.com/6013068/176884939-ade8d742-199b-434f-b3b1-55a02965d32b.png) |
