### PR TITLE
Fix incorrect background color in code editor

### DIFF
--- a/web/src/components/CompareSide.vue
+++ b/web/src/components/CompareSide.vue
@@ -241,5 +241,9 @@ pre.highlighted-code {
   code {
     background-color: unset !important;
   }
+
+  pre {
+    background-color: unset !important;
+  }
 }
 </style>


### PR DESCRIPTION
Vuetify appends a background color to `<pre>`-blocks which makes the editor darker as it suppose to and causes some weird highlighting on operators.

| Before | After |
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/6013068/176896250-5156d86f-c9be-4812-903d-61d363589362.png) | ![image](https://user-images.githubusercontent.com/6013068/176896286-2cda7d2d-8c40-4447-b101-104c44595b50.png)|
