### PR TITLE
Bump node versions: perform tests with node 14, 16 and 18

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ "12", "14", "16" ]
+        node: [ "14", "16", "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -38,7 +38,7 @@ jobs:
     needs: install-deps
     strategy:
       matrix:
-        node:  [ "12", "14", "16" ]
+        node:  [ "14", "16", "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -75,7 +75,7 @@ jobs:
     needs: install-deps
     strategy:
       matrix:
-        node: [ "16" ]
+        node: [ "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -112,7 +112,7 @@ jobs:
     needs: install-deps
     strategy:
       matrix:
-        node: [ "12", "14", "16" ]
+        node: [ "14", "16", "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -150,7 +150,7 @@ jobs:
     needs: install-deps
     strategy:
       matrix:
-        node: [ "16" ]
+        node: [ "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -188,7 +188,7 @@ jobs:
     needs: install-deps
     strategy:
       matrix:
-        node: [ "12", "14", "16" ]
+        node: [ "14", "16", "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -256,7 +256,7 @@ jobs:
     needs: install-deps
     strategy:
       matrix:
-        node: [ "16" ]
+        node: [ "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -293,7 +293,7 @@ jobs:
     needs: install-deps
     strategy:
       matrix:
-        node:  [ "16" ]
+        node:  [ "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -353,7 +353,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
-        node:  [ "16" ]
+        node:  [ "18" ]
       fail-fast: false
     steps:
       - name: Checkout 🛎️
@@ -467,7 +467,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ "16" ]
+        node: [ "18" ]
       fail-fast: false
     steps:
       - name: Setup Node 📚


### PR DESCRIPTION
Node 12 has left its maintenance window and Node 18 is the current LTS, so this changes the CI tests to reflect this change.