### PR TITLE
Upgrade to Vue 2.7

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "@types/prismjs": "^1.16.5",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
-    "@vue/cli": "~5.0.6",
+    "@vue/cli": "~5.0.8",
     "@vue/cli-plugin-babel": "~5.0.8",
     "@vue/cli-plugin-eslint": "~5.0.8",
     "@vue/cli-plugin-router": "~5.0.8",
@@ -23,7 +23,6 @@
     "@vue/cli-service": "~5.0.8",
     "@vue/eslint-config-standard": "^6.0.0",
     "@vue/eslint-config-typescript": "^7.0.0",
-    "@vue/runtime-dom": "^3.2.37",
     "core-js": "^3.17.3",
     "eslint": "^7.27.0",
     "eslint-plugin-import": "^2.24.2",
@@ -36,22 +35,20 @@
     "sass-loader": "^13.0.0",
     "typescript": "~4.5.5",
     "vue-cli-plugin-vuetify": "~2.5.1",
-    "vue-template-compiler": "^2.6.13",
-    "vuetify-loader": "^1.7.3"
+    "vuetify-loader": "^1.9.2"
   },
   "dependencies": {
     "@dodona/dolos-lib": "1.7.0",
     "@mdi/font": "^6.5.95",
-    "@vue/composition-api": "^1.6.2",
-    "@vueuse/core": "^8.7.5",
+    "@vueuse/core": "^9.0.2",
     "d3": "^7.0.0",
     "luxon": "^2.3.1",
-    "pinia": "^2.0.14",
+    "pinia": "^2.0.17",
     "prismjs": "^1.20.0",
     "roboto-fontface": "*",
-    "vue": "^2.6.13",
+    "vue": "^2.7.8",
     "vue-router": "^3.5.1",
-    "vuetify": "^2.5.3"
+    "vuetify": "^2.6.8"
   },
   "license": "MIT",
   "publishConfig": {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -115,7 +115,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, shallowRef, computed } from "@vue/composition-api";
+import { defineComponent, shallowRef, computed } from "vue";
 import { storeToRefs } from "pinia";
 import { useRouter, useBreakpoints } from "@/composables";
 import { useApiStore } from "@/api/stores";

--- a/web/src/api/stores/api.store.ts
+++ b/web/src/api/stores/api.store.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { shallowRef, watch } from "@vue/composition-api";
+import { shallowRef, watch } from "vue";
 import { getInterpolatedSimilarity } from "@/api/utils";
 import {
   useFileStore,

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { shallowRef, computed } from "@vue/composition-api";
+import { shallowRef, computed } from "vue";
 import { DATA_URL } from "@/api";
 import { File, ObjMap } from "@/api/models";
 import { useApiStore } from "@/api/stores";

--- a/web/src/api/stores/kgram.store.ts
+++ b/web/src/api/stores/kgram.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { shallowRef } from "@vue/composition-api";
+import { shallowRef } from "vue";
 import { DATA_URL } from "@/api";
 import { Kgram, File, ObjMap } from "@/api/models";
 import { assertType } from "@/api/utils";

--- a/web/src/api/stores/metadata.store.ts
+++ b/web/src/api/stores/metadata.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { shallowRef } from "@vue/composition-api";
+import { shallowRef } from "vue";
 import { DATA_URL } from "@/api";
 import { Metadata } from "@/api/models";
 import { castToType } from "@/api/utils";

--- a/web/src/api/stores/pair.store.ts
+++ b/web/src/api/stores/pair.store.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { defineStore } from "pinia";
-import { shallowRef, computed } from "@vue/composition-api";
+import { shallowRef, computed } from "vue";
 import { DATA_URL } from "@/api";
 import { assertType, fileToTokenizedFile } from "@/api/utils";
 import {

--- a/web/src/api/stores/semantic.store.ts
+++ b/web/src/api/stores/semantic.store.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { shallowRef, computed } from "@vue/composition-api";
+import { shallowRef, computed } from "vue";
 import { DATA_URL } from "@/api";
 import { Semantic, ObjMap, File } from "@/api/models";
 import { useFileStore, useMetadataStore } from "@/api/stores";

--- a/web/src/components/BarcodeChart.vue
+++ b/web/src/components/BarcodeChart.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed, watch, onMounted } from "@vue/composition-api";
+import { defineComponent, PropType, computed, watch, onMounted } from "vue";
 import { Selection } from "@/api/models";
 import { constructID } from "@/util/OccurenceHighlight";
 import * as d3 from "d3";

--- a/web/src/components/ClusteringTable.vue
+++ b/web/src/components/ClusteringTable.vue
@@ -35,7 +35,7 @@ import {
   shallowRef,
   computed,
   watch,
-} from "@vue/composition-api";
+} from "vue";
 import { storeToRefs } from "pinia";
 import { useVuetify, useRoute } from "@/composables";
 import { useApiStore } from "@/api/stores";

--- a/web/src/components/CompareCard.vue
+++ b/web/src/components/CompareCard.vue
@@ -194,7 +194,7 @@ import {
   computed,
   onMounted,
   watch,
-} from "@vue/composition-api";
+} from "vue";
 import { Pair, Metadata, Selection, File, Fragment } from "@/api/models";
 import { fileToTokenizedFile } from "@/api/utils";
 import { constructID, SelectionId } from "@/util/OccurenceHighlight";

--- a/web/src/components/CompareSide.vue
+++ b/web/src/components/CompareSide.vue
@@ -40,7 +40,7 @@ import {
   watch,
   onMounted,
   onUnmounted,
-} from "@vue/composition-api";
+} from "vue";
 import { Selection, File } from "@/api/models";
 import {
   ID_START,

--- a/web/src/components/FragmentItem.vue
+++ b/web/src/components/FragmentItem.vue
@@ -35,7 +35,7 @@ import {
   PropType,
   computed,
   watch,
-} from "@vue/composition-api";
+} from "vue";
 import { Fragment } from "@/api/models";
 import { useVModel } from "@vueuse/core";
 

--- a/web/src/components/FragmentList.vue
+++ b/web/src/components/FragmentList.vue
@@ -114,7 +114,7 @@ import {
   watch,
   onMounted,
   onUnmounted,
-} from "@vue/composition-api";
+} from "vue";
 import { useVModel } from "@vueuse/core";
 import { Fragment, Pair, Selection } from "@/api/models";
 import { fileToTokenizedFile } from "@/api/utils";

--- a/web/src/components/PairsTable.vue
+++ b/web/src/components/PairsTable.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed, shallowRef } from "@vue/composition-api";
+import { defineComponent, PropType, computed, shallowRef } from "vue";
 import { useRouter, useRoute } from "@/composables";
 import { Pair, ObjMap } from "@/api/models";
 

--- a/web/src/components/SemanticList.vue
+++ b/web/src/components/SemanticList.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed } from "@vue/composition-api";
+import { defineComponent, PropType, computed } from "vue";
 import { useVModel } from "@vueuse/core";
 import { File } from "@/api/models";
 import { SemanticMatch } from "@/components/CompareCard.vue";

--- a/web/src/components/clustering/ClusteringCard.vue
+++ b/web/src/components/clustering/ClusteringCard.vue
@@ -55,7 +55,7 @@ import {
   shallowRef,
   computed,
   toRef,
-} from "@vue/composition-api";
+} from "vue";
 import { useCluster } from "@/composables";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
 import { getClusterElementsArray } from "@/util/clustering-algorithms/ClusterFunctions";

--- a/web/src/components/clustering/FileTagList.vue
+++ b/web/src/components/clustering/FileTagList.vue
@@ -11,7 +11,7 @@ import {
   watch,
   onMounted,
   toRef,
-} from "@vue/composition-api";
+} from "vue";
 import { useElementSize } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { useFileStore } from "@/api/stores";

--- a/web/src/components/clustering/GraphTab.vue
+++ b/web/src/components/clustering/GraphTab.vue
@@ -32,7 +32,7 @@ import {
   shallowRef,
   watch,
   onMounted,
-} from "@vue/composition-api";
+} from "vue";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
 import { getClusterElementsArray } from "@/util/clustering-algorithms/ClusterFunctions";
 import { Pair, File } from "@/api/models";

--- a/web/src/components/clustering/HeatMap.vue
+++ b/web/src/components/clustering/HeatMap.vue
@@ -60,7 +60,7 @@ import {
   watch,
   onMounted,
   toRef,
-} from "@vue/composition-api";
+} from "vue";
 import { storeToRefs } from "pinia";
 import { useFileStore, usePairStore, useApiStore } from "@/api/stores";
 import { useCluster, useRouter } from "@/composables";

--- a/web/src/components/clustering/TimeSeries.vue
+++ b/web/src/components/clustering/TimeSeries.vue
@@ -13,7 +13,7 @@ import {
   watch,
   toRef,
   onMounted,
-} from "@vue/composition-api";
+} from "vue";
 import { storeToRefs } from "pinia";
 import { useApiStore } from "@/api/stores";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";

--- a/web/src/components/clustering/TimeSeriesCard.vue
+++ b/web/src/components/clustering/TimeSeriesCard.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, shallowRef } from "@vue/composition-api";
+import { defineComponent, PropType, shallowRef } from "vue";
 import { File } from "@/api/models";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
 import TimeSeriesDiagram from "@/components/clustering/TimeSeries.vue";

--- a/web/src/components/graph/Graph.vue
+++ b/web/src/components/graph/Graph.vue
@@ -14,7 +14,7 @@ import {
   watch,
   onMounted,
   onUnmounted,
-} from "@vue/composition-api";
+} from "vue";
 import { useApiStore } from "@/api/stores";
 import { Pair, File, Legend } from "@/api/models";
 import { useCluster } from "@/composables";

--- a/web/src/components/overview/OverviewBarchart.vue
+++ b/web/src/components/overview/OverviewBarchart.vue
@@ -11,7 +11,7 @@ import {
   computed,
   watch,
   onMounted,
-} from "@vue/composition-api";
+} from "vue";
 import { storeToRefs } from "pinia";
 import { useFileStore, usePairStore } from "@/api/stores";
 import { FileInterestingnessCalculator } from "@/util/FileInterestingness";

--- a/web/src/components/summary/FileCard.vue
+++ b/web/src/components/summary/FileCard.vue
@@ -180,7 +180,7 @@ import {
   computed,
   shallowRef,
   watch,
-} from "@vue/composition-api";
+} from "vue";
 import {
   FileScoring,
   getLargestFieldOfScore,

--- a/web/src/components/summary/FileCardScore.vue
+++ b/web/src/components/summary/FileCardScore.vue
@@ -82,7 +82,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed } from "@vue/composition-api";
+import { defineComponent, PropType, computed } from "vue";
 import { FileScoring } from "@/util/FileInterestingness";
 import { File, Pair } from "@/api/models";
 

--- a/web/src/components/summary/PairStatHistogram.vue
+++ b/web/src/components/summary/PairStatHistogram.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, shallowRef, computed, watch, onMounted } from "@vue/composition-api";
+import { defineComponent, PropType, shallowRef, computed, watch, onMounted } from "vue";
 import { TooltipTool } from "@/d3-tools/TooltipTool";
 import { FileScoring } from "@/util/FileInterestingness";
 import { useElementSize } from "@vueuse/core";

--- a/web/src/components/summary/SummaryList.vue
+++ b/web/src/components/summary/SummaryList.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, shallowRef, computed, watch } from "@vue/composition-api";
+import { defineComponent, shallowRef, computed, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { Pair } from "@/api/models";
 import { useFileStore, usePairStore } from "@/api/stores";

--- a/web/src/components/summary/SummaryVisualisation.vue
+++ b/web/src/components/summary/SummaryVisualisation.vue
@@ -43,7 +43,7 @@ import {
   shallowRef,
   watch,
   onMounted,
-} from "@vue/composition-api";
+} from "vue";
 import { FileScoring } from "@/util/FileInterestingness";
 import {
   DecodedSemanticResult,

--- a/web/src/composables/useBreakpoints.ts
+++ b/web/src/composables/useBreakpoints.ts
@@ -1,4 +1,4 @@
-import { computed, ComputedRef } from "@vue/composition-api";
+import { computed, ComputedRef } from "vue";
 import { Breakpoint } from "vuetify/types/services/breakpoint";
 import { useVuetify } from "@/composables";
 

--- a/web/src/composables/useCluster.ts
+++ b/web/src/composables/useCluster.ts
@@ -1,4 +1,4 @@
-import { ComputedRef, computed, unref } from "@vue/composition-api";
+import { ComputedRef, computed, unref } from "vue";
 import { MaybeRef } from "@/util/Types";
 import { File } from "@/api/models";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";

--- a/web/src/composables/useClustering.ts
+++ b/web/src/composables/useClustering.ts
@@ -1,4 +1,4 @@
-import { ComputedRef, computed } from "@vue/composition-api";
+import { ComputedRef, computed } from "vue";
 import { useApiStore, usePairStore, useFileStore } from "@/api/stores";
 import { singleLinkageCluster } from "@/util/clustering-algorithms/SingleLinkageClustering";
 import { Clustering } from "@/util/clustering-algorithms/ClusterTypes";

--- a/web/src/composables/useLegend.ts
+++ b/web/src/composables/useLegend.ts
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import { ComputedRef, computed, unref } from "@vue/composition-api";
+import { ComputedRef, computed, unref } from "vue";
 import { MaybeRef } from "@/util/Types";
 import { File, ObjMap } from "@/api/models";
 import { useFileStore } from "@/api/stores";

--- a/web/src/composables/useRoute.ts
+++ b/web/src/composables/useRoute.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, computed, ComputedRef } from "@vue/composition-api";
+import { getCurrentInstance, computed, ComputedRef } from "vue";
 import { Route } from "vue-router";
 
 /**

--- a/web/src/composables/useRouter.ts
+++ b/web/src/composables/useRouter.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance } from "@vue/composition-api";
+import { getCurrentInstance } from "vue";
 import VueRouter from "vue-router";
 
 /**

--- a/web/src/composables/useVuetify.ts
+++ b/web/src/composables/useVuetify.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance } from "@vue/composition-api";
+import { getCurrentInstance } from "vue";
 import { Framework } from "vuetify";
 
 /**

--- a/web/src/d3-tools/GraphElementList.vue
+++ b/web/src/d3-tools/GraphElementList.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, computed, watch } from "@vue/composition-api";
+import { defineComponent, PropType, computed, watch } from "vue";
 import { File } from "@/api/models";
 import { Cluster } from "@/util/clustering-algorithms/ClusterTypes";
 import { getClusterElementsArray } from "@/util/clustering-algorithms/ClusterFunctions";

--- a/web/src/d3-tools/GraphLegend.vue
+++ b/web/src/d3-tools/GraphLegend.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "@vue/composition-api";
+import { defineComponent, PropType } from "vue";
 import { File, Legend } from "@/api/models";
 import { useVModel } from "@vueuse/core";
 

--- a/web/src/d3-tools/GraphSelectedInfo.vue
+++ b/web/src/d3-tools/GraphSelectedInfo.vue
@@ -51,7 +51,7 @@ import {
   PropType,
   computed,
   toRef,
-} from "@vue/composition-api";
+} from "vue";
 import { useCluster, useVuetify, useRouter } from "@/composables";
 import { File } from "@/api/models";
 import { Cluster, Clustering } from "@/util/clustering-algorithms/ClusterTypes";

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,4 @@
 import Vue from "vue";
-import VueCompositionAPI, { createApp } from "@vue/composition-api";
 import { PiniaVuePlugin, createPinia } from "pinia";
 import App from "./App.vue";
 import router from "./router";
@@ -10,17 +9,14 @@ import "@mdi/font/css/materialdesignicons.css";
 
 Vue.config.productionTip = false;
 
-Vue.use(VueCompositionAPI);
 Vue.use(PiniaVuePlugin);
 
 const pinia = createPinia();
-const app = createApp({
+const app = new Vue({
   vuetify,
   router,
   pinia,
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   render: (h) => h(App),
 });
 
-app.mount("#app");
+app.$mount("#app");

--- a/web/src/util/Types.ts
+++ b/web/src/util/Types.ts
@@ -1,4 +1,4 @@
-import { Ref } from "@vue/composition-api";
+import { Ref } from "vue";
 
 export type SortingFunction<T> = (a: T, b:T) => number;
 export type MaybeRef<T> = T | Ref<T>;

--- a/web/src/views/Compare.vue
+++ b/web/src/views/Compare.vue
@@ -27,7 +27,7 @@ import {
   shallowRef,
   computed,
   watch,
-} from "@vue/composition-api";
+} from "vue";
 import { usePairStore, useMetadataStore, useFileStore } from "@/api/stores";
 import CompareCard from "@/components/CompareCard.vue";
 import Loading from "@/components/Loading.vue";

--- a/web/src/views/FileAnalysis.vue
+++ b/web/src/views/FileAnalysis.vue
@@ -9,7 +9,7 @@
   </v-row>
 </template>
 <script lang="ts">
-import { defineComponent } from "@vue/composition-api";
+import { defineComponent } from "vue";
 import SummaryCard from "@/components/summary/SummaryCard.vue";
 import SummaryList from "@/components/summary/SummaryList.vue";
 

--- a/web/src/views/GraphView.vue
+++ b/web/src/views/GraphView.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, shallowRef, computed } from "@vue/composition-api";
+import { defineComponent, ref, shallowRef, computed } from "vue";
 import { storeToRefs } from "pinia";
 import { File, Legend } from "@/api/models";
 import { Cluster } from "@/util/Cluster";

--- a/web/src/views/Overview.vue
+++ b/web/src/views/Overview.vue
@@ -195,7 +195,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "@vue/composition-api";
+import { defineComponent, computed } from "vue";
 import { storeToRefs } from "pinia";
 import { useBreakpoints, useClustering } from "@/composables";
 import { Pair } from "@/api/models";

--- a/web/src/views/Pairs.vue
+++ b/web/src/views/Pairs.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "@vue/composition-api";
+import { defineComponent } from "vue";
 import { usePairStore } from "@/api/stores";
 import PairsTable from "@/components/PairsTable.vue";
 

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -31,6 +31,6 @@
   ],
   "exclude": ["node_modules"],
   "vueCompilerOptions": {
-    "target": 2
+    "target": 2.7
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,14 @@
     "@graphql-tools/utils" "8.8.0"
     tslib "^2.4.0"
 
+"@graphql-tools/merge@8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.1.tgz#06121942ad28982a14635dbc87b5d488a041d722"
+  integrity sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==
+  dependencies:
+    "@graphql-tools/utils" "8.9.0"
+    tslib "^2.4.0"
+
 "@graphql-tools/mock@^8.1.2":
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/mock/-/mock-8.7.0.tgz#da286596ef05b84165e76cf6f608eeea4109a60c"
@@ -1159,10 +1167,27 @@
     tslib "^2.4.0"
     value-or-promise "1.0.11"
 
+"@graphql-tools/schema@^8.5.0":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.5.1.tgz#c2f2ff1448380919a330312399c9471db2580b58"
+  integrity sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==
+  dependencies:
+    "@graphql-tools/merge" "8.3.1"
+    "@graphql-tools/utils" "8.9.0"
+    tslib "^2.4.0"
+    value-or-promise "1.0.11"
+
 "@graphql-tools/utils@8.8.0":
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.8.0.tgz#8332ff80a1da9204ccf514750dd6f5c5cccf17dc"
   integrity sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==
+  dependencies:
+    tslib "^2.4.0"
+
+"@graphql-tools/utils@8.9.0":
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.9.0.tgz#c6aa5f651c9c99e1aca55510af21b56ec296cdb7"
+  integrity sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==
   dependencies:
     tslib "^2.4.0"
 
@@ -2055,10 +2080,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/web-bluetooth@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.14.tgz#94e175b53623384bff1f354cdb3197a8d63cdbe5"
-  integrity sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A==
+"@types/web-bluetooth@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.15.tgz#d60330046a6ed8a13b4a53df3813c44942ebdf72"
+  integrity sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA==
 
 "@types/webpack-dev-server@^3":
   version "3.11.6"
@@ -2483,24 +2508,6 @@
     webpack-virtual-modules "^0.4.2"
     whatwg-fetch "^3.6.2"
 
-"@vue/cli-shared-utils@^5.0.7":
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@vue/cli-shared-utils/-/cli-shared-utils-5.0.7.tgz#c6774573ea2e8106e11d3d6df342c2bd2554330a"
-  integrity sha512-SzpqSExsp31gg7w+UAsqdrFyZGxKNTIE8MVwcfkevEx4BgugpLcmUxgcelgDktMs7GGykxluPIm0ZHDk3ytXeg==
-  dependencies:
-    "@achrinza/node-ipc" "^9.2.5"
-    chalk "^4.1.2"
-    execa "^1.0.0"
-    joi "^17.4.0"
-    launch-editor "^2.2.1"
-    lru-cache "^6.0.0"
-    node-fetch "^2.6.7"
-    open "^8.0.2"
-    ora "^5.3.0"
-    read-pkg "^5.1.1"
-    semver "^7.3.4"
-    strip-ansi "^6.0.0"
-
 "@vue/cli-shared-utils@^5.0.8":
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/@vue/cli-shared-utils/-/cli-shared-utils-5.0.8.tgz#75fc96528eba2b1c7e33cb7e989a984ddef99c8a"
@@ -2519,24 +2526,25 @@
     semver "^7.3.4"
     strip-ansi "^6.0.0"
 
-"@vue/cli-ui-addon-webpack@^5.0.7":
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-5.0.7.tgz#30b2d8eb18f101bc0e9d0fdb42988c1b25109773"
-  integrity sha512-6We7vMjZok2/QbsgTVE1oF50pry5MFG9Oj2hd2MNs0Onzft9b2K240ee7lwFXzoPD8FhFrMTU+WNzBU2mFYLMA==
+"@vue/cli-ui-addon-webpack@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@vue/cli-ui-addon-webpack/-/cli-ui-addon-webpack-5.0.8.tgz#84314374f3fbf03a6e565c362ce01c0270a18e84"
+  integrity sha512-sg+3a9vHGzpFRrv7MVZRQ9oDztFN9Mvx0MleidKyPIAWMSOskSQT8zTngy8bEyXjXwNv6mCn2jvUR/tgbldyow==
 
-"@vue/cli-ui-addon-widgets@^5.0.7":
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-5.0.7.tgz#c45a11e61bed728f1c385f307ab948dc564a1f9b"
-  integrity sha512-JjOn4LXZ6K7ErgWBbSciqHOy8hQvrQncbPP1F8ydCOa1ok+OR02UePbVI9ct0DE3LjbnBbdMxvDjJJB7hPnyxg==
+"@vue/cli-ui-addon-widgets@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@vue/cli-ui-addon-widgets/-/cli-ui-addon-widgets-5.0.8.tgz#6f073f2bc975162468e5a6b93f074e25f8f64460"
+  integrity sha512-jNYQ+3z7HDZ3IR3Z3Dlo3yOPbHexpygkn2IJ7sjA62oGolnNWeF7kvpLwni18l8N5InhS66m9w31an1Fs5pCZA==
 
-"@vue/cli-ui@^5.0.7":
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@vue/cli-ui/-/cli-ui-5.0.7.tgz#e6f15cf4133d0a86fe61268cf641ee2edb53623b"
-  integrity sha512-SC8TZMeDMuQefJDhxUWTeDacsziRApX1vyFix/Di0Vzfs7nCeIkaI3+mjE1LvvCv6OqC5jL1G3fCIaSO1Sn50A==
+"@vue/cli-ui@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@vue/cli-ui/-/cli-ui-5.0.8.tgz#f6e817d54186f648807a906cd0898eecdaaf3ca9"
+  integrity sha512-1eyL1h1T3LVejYplDqERO8TK03sjR3QTOTHa01ABreCdqFTZItiUVud34uEcuoZ6Gi69xdl+LSx6Hvo4t9tfrA==
   dependencies:
     "@achrinza/node-ipc" "^9.2.5"
     "@akryum/winattr" "^3.0.0"
-    "@vue/cli-shared-utils" "^5.0.7"
+    "@graphql-tools/schema" "^8.5.0"
+    "@vue/cli-shared-utils" "^5.0.8"
     apollo-server-express "^3.9.0"
     clone "^2.1.1"
     deepmerge "^4.2.2"
@@ -2560,19 +2568,20 @@
     prismjs "^1.23.0"
     rss-parser "^3.11.0"
     shortid "^2.2.15"
+    subscriptions-transport-ws "^0.11.0"
     typescript "~4.5.5"
 
-"@vue/cli@~5.0.6":
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@vue/cli/-/cli-5.0.7.tgz#db1d0d6376cea81f1ab337157e24c6721597110c"
-  integrity sha512-iJ++nbxoPrSIJcALfxHGG2izd7VEMPL+30Ga+CgMh1hhbro1vN1xUveFKOGqHEj7IEGVWIcREcgn2FAh9nrgxA==
+"@vue/cli@~5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@vue/cli/-/cli-5.0.8.tgz#97b2bad9cb331dcffdd4fbe8532bdeacd2441166"
+  integrity sha512-c/QKPdC09bYkW22m/boXkLaiz10z0Z2WHZO7zEeNdfSduqyWINZhKc6hVQU3Vk0NXW7BJAd7zWmcUrC8L9TuAA==
   dependencies:
     "@types/ejs" "^3.0.6"
     "@types/inquirer" "^8.1.3"
-    "@vue/cli-shared-utils" "^5.0.7"
-    "@vue/cli-ui" "^5.0.7"
-    "@vue/cli-ui-addon-webpack" "^5.0.7"
-    "@vue/cli-ui-addon-widgets" "^5.0.7"
+    "@vue/cli-shared-utils" "^5.0.8"
+    "@vue/cli-ui" "^5.0.8"
+    "@vue/cli-ui-addon-webpack" "^5.0.8"
+    "@vue/cli-ui-addon-widgets" "^5.0.8"
     boxen "^5.0.0"
     commander "^7.1.0"
     debug "^4.1.0"
@@ -2630,6 +2639,15 @@
     postcss "^8.4.14"
     source-map "^0.6.1"
 
+"@vue/compiler-sfc@2.7.8":
+  version "2.7.8"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.8.tgz#731aadd6beafdb9c72fd8614ce189ac6cee87612"
+  integrity sha512-2DK4YWKfgLnW9VDR9gnju1gcYRk3flKj8UNsms7fsRmFcg35slVTZEkqwBtX+wJBXaamFfn6NxSsZh3h12Ix/Q==
+  dependencies:
+    "@babel/parser" "^7.18.4"
+    postcss "^8.4.14"
+    source-map "^0.6.1"
+
 "@vue/component-compiler-utils@^3.1.0", "@vue/component-compiler-utils@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.3.0.tgz#f9f5fb53464b0c37b2c8d2f3fbfe44df60f61dc9"
@@ -2646,15 +2664,10 @@
   optionalDependencies:
     prettier "^1.18.2 || ^2.0.0"
 
-"@vue/composition-api@^1.6.2":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.6.3.tgz#3b1486608f1682e8bc03c71e1fd58013b0b7a093"
-  integrity sha512-f0TgOKqU460QyVLp5URi8LMVJ3eE3/3OuFrytItSNmp5FbisS67jVvUZg7pzIzZonqc4chG1SNS48PMOsH7a4g==
-
-"@vue/devtools-api@^6.1.4":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.1.4.tgz#b4aec2f4b4599e11ba774a50c67fa378c9824e53"
-  integrity sha512-IiA0SvDrJEgXvVxjNkHPFfDx6SXw0b/TUkqMcDZWNg9fnCAHbTpoo59YfJ9QLFkwa3raau5vSlRVzMSLDnfdtQ==
+"@vue/devtools-api@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.2.1.tgz#6f2948ff002ec46df01420dfeff91de16c5b4092"
+  integrity sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ==
 
 "@vue/eslint-config-standard@^6.0.0":
   version "6.1.0"
@@ -2671,30 +2684,6 @@
   integrity sha512-UxUlvpSrFOoF8aQ+zX1leYiEBEm7CZmXYn/ZEM1zwSadUzpamx56RB4+Htdjisv1mX2tOjBegNUqH3kz2OL+Aw==
   dependencies:
     vue-eslint-parser "^7.0.0"
-
-"@vue/reactivity@3.2.37":
-  version "3.2.37"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.37.tgz#5bc3847ac58828e2b78526e08219e0a1089f8848"
-  integrity sha512-/7WRafBOshOc6m3F7plwzPeCu/RCVv9uMpOwa/5PiY1Zz+WLVRWiy0MYKwmg19KBdGtFWsmZ4cD+LOdVPcs52A==
-  dependencies:
-    "@vue/shared" "3.2.37"
-
-"@vue/runtime-core@3.2.37":
-  version "3.2.37"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.37.tgz#7ba7c54bb56e5d70edfc2f05766e1ca8519966e3"
-  integrity sha512-JPcd9kFyEdXLl/i0ClS7lwgcs0QpUAWj+SKX2ZC3ANKi1U4DOtiEr6cRqFXsPwY5u1L9fAjkinIdB8Rz3FoYNQ==
-  dependencies:
-    "@vue/reactivity" "3.2.37"
-    "@vue/shared" "3.2.37"
-
-"@vue/runtime-dom@^3.2.37":
-  version "3.2.37"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.37.tgz#002bdc8228fa63949317756fb1e92cdd3f9f4bbd"
-  integrity sha512-HimKdh9BepShW6YozwRKAYjYQWg9mQn63RGEiSswMbW+ssIht1MILYlVGkAGGQbkhSh31PCdoUcfiu4apXJoPw==
-  dependencies:
-    "@vue/runtime-core" "3.2.37"
-    "@vue/shared" "3.2.37"
-    csstype "^2.6.8"
 
 "@vue/shared@3.2.37":
   version "3.2.37"
@@ -2865,25 +2854,25 @@
     "@types/webpack-dev-server" "^3"
     webpack-chain "^6.0.0"
 
-"@vueuse/core@^8.7.5":
-  version "8.7.5"
-  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-8.7.5.tgz#e74a888251ea11a9d432068ce18cbdfc4f810251"
-  integrity sha512-tqgzeZGoZcXzoit4kOGLWJibDMLp0vdm6ZO41SSUQhkhtrPhAg6dbIEPiahhUu6sZAmSYvVrZgEr5aKD51nrLA==
+"@vueuse/core@^9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-9.0.2.tgz#e6e59c45b43c1ffe4ad5149853a1ea4e8f1e3b12"
+  integrity sha512-kOIqaQPSs7OSByWg1ulEKRUJbsq3FmbJiUr0RhEKpt3O1Uhl4DrDj85DUbQBABVYgPvSaY6AE/fP3/FOcRIOoQ==
   dependencies:
-    "@types/web-bluetooth" "^0.0.14"
-    "@vueuse/metadata" "8.7.5"
-    "@vueuse/shared" "8.7.5"
+    "@types/web-bluetooth" "^0.0.15"
+    "@vueuse/metadata" "9.0.2"
+    "@vueuse/shared" "9.0.2"
     vue-demi "*"
 
-"@vueuse/metadata@8.7.5":
-  version "8.7.5"
-  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-8.7.5.tgz#c7f2b21d873d1604a8860ed9c5728d8f3295f00a"
-  integrity sha512-emJZKRQSaEnVqmlu39NpNp8iaW+bPC2kWykWoWOZMSlO/0QVEmO/rt8A5VhOEJTKLX3vwTevqbiRy9WJRwVOQg==
+"@vueuse/metadata@9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-9.0.2.tgz#373fdeb552f2a002ddc1f36c4027c936d78f8cb5"
+  integrity sha512-TRh+TNUYXiodatSAxd0xZc7sh4RfktVVgNFIN7TCQXKyancbCAcWfHvKfgdlX8LcqSBxKoHVa90n0XdUbboTkw==
 
-"@vueuse/shared@8.7.5":
-  version "8.7.5"
-  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-8.7.5.tgz#06fb08f6f8fc9e90be9d1e033fa443de927172b0"
-  integrity sha512-THXPvMBFmg6Gf6AwRn/EdTh2mhqwjGsB2Yfp374LNQSQVKRHtnJ0I42bsZTn7nuEliBxqUrGQm/lN6qUHmhJLw==
+"@vueuse/shared@9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-9.0.2.tgz#d3fb03594a9482d264702c67efe71d691ce67084"
+  integrity sha512-KwBDefK2ljLESpt0ffe2w8EGUCb3IaMfTzeytB/uHHjHOGOEIHLHHyn8W2C48uGQEvoe5iwaW4Bfp8cRUM6IFA==
   dependencies:
     vue-demi "*"
 
@@ -3914,6 +3903,11 @@ babel-plugin-polyfill-regenerator@^0.3.1:
   integrity sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
+
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -5618,11 +5612,6 @@ csso@^4.0.2, csso@^4.2.0:
   dependencies:
     css-tree "^1.1.2"
 
-csstype@^2.6.8:
-  version "2.6.20"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.20.tgz#9229c65ea0b260cf4d3d997cb06288e36a8d6dda"
-  integrity sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==
-
 csstype@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
@@ -7148,6 +7137,11 @@ event-pubsub@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/event-pubsub/-/event-pubsub-4.3.0.tgz#f68d816bc29f1ec02c539dc58c8dd40ce72cb36e"
   integrity sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==
+
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 eventemitter3@^4.0.0:
   version "4.0.7"
@@ -9560,7 +9554,7 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-iterall@^1.3.0:
+iterall@^1.2.1, iterall@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -11844,12 +11838,12 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pinia@^2.0.14:
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.14.tgz#0837898c20291ebac982bbfca95c8d3c6099925f"
-  integrity sha512-0nPuZR4TetT/WcLN+feMSjWJku3SQU7dBbXC6uw+R6FLQJCsg+/0pzXyD82T1FmAYe0lsx+jnEDQ1BLgkRKlxA==
+pinia@^2.0.17:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.17.tgz#f925e5e4f73c15e16dfb4838176a9ca50752f26b"
+  integrity sha512-AtwLwEWQgIjofjgeFT+nxbnK5lT2QwQjaHNEDqpsi2AiCwf/NY78uWTeHUyEhiiJy8+sBmw0ujgQMoQbWiZDfA==
   dependencies:
-    "@vue/devtools-api" "^6.1.4"
+    "@vue/devtools-api" "^6.2.1"
     vue-demi "*"
 
 pinkie-promise@^2.0.0:
@@ -14270,6 +14264,17 @@ stylus@^0.54.8:
     semver "^6.3.0"
     source-map "^0.7.3"
 
+subscriptions-transport-ws@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz#baf88f050cba51d52afe781de5e81b3c31f89883"
+  integrity sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0 || ^6.0.0 || ^7.0.0"
+
 supertap@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/supertap/-/supertap-3.0.1.tgz#aa89e4522104402c6e8fe470a7d2db6dc4037c6a"
@@ -14363,7 +14368,7 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
-symbol-observable@^1.1.0:
+symbol-observable@^1.0.4, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -15403,7 +15408,7 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.3:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.6.10, vue-template-compiler@^2.6.13:
+vue-template-compiler@^2.6.10:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz#a2f0e7d985670d42c9c9ee0d044fed7690f4f763"
   integrity sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==
@@ -15416,7 +15421,7 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.6.10, vue@^2.6.13:
+vue@^2.6.10:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
@@ -15427,6 +15432,14 @@ vue@^2.6.14:
   integrity sha512-7MTirXG7LYJi3r2jeYy7EiXIhEE85uP3kBwSxqwDsvIfy/l7+qR4U6ajw8ji1KoP+wYYg7ZY28TBTf3P3Fa4Nw==
   dependencies:
     "@vue/compiler-sfc" "2.7.3"
+    csstype "^3.1.0"
+
+vue@^2.7.8:
+  version "2.7.8"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.8.tgz#34e06553137611d8cecc4b0cd78b7a59f80b1299"
+  integrity sha512-ncwlZx5qOcn754bCu5/tS/IWPhXHopfit79cx+uIlLMyt3vCMGcXai5yCG5y+I6cDmEj4ukRYyZail9FTQh7lQ==
+  dependencies:
+    "@vue/compiler-sfc" "2.7.8"
     csstype "^3.1.0"
 
 vuepress-html-webpack-plugin@^3.2.0:
@@ -15470,19 +15483,21 @@ vuepress@^1.9.7:
     opencollective-postinstall "^2.0.2"
     update-notifier "^4.0.0"
 
-vuetify-loader@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/vuetify-loader/-/vuetify-loader-1.7.3.tgz#404657f4925c828f400fe3269003421d586835c6"
-  integrity sha512-1Kt6Rfvuw3i9BBlxC9WTMnU3WEU7IBWQmDX+fYGAVGpzWCX7oHythUIwPCZGShHSYcPMKSDbXTPP8UvT5RNw8Q==
+vuetify-loader@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/vuetify-loader/-/vuetify-loader-1.9.2.tgz#adcadac71c6d9b24bde42a5b81dfda1871f73f81"
+  integrity sha512-8PP2w7aAs/rjA+Izec6qY7sHVb75MNrGQrDOTZJ5IEnvl+NiFhVpU2iWdRDZ3eMS842cWxSWStvkr+KJJKy+Iw==
   dependencies:
+    acorn "^8.4.1"
+    acorn-walk "^8.2.0"
     decache "^4.6.0"
     file-loader "^6.2.0"
     loader-utils "^2.0.0"
 
-vuetify@^2.5.3:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.6.6.tgz#7af178fece5ccd561639eba425fe6c0a5803b37e"
-  integrity sha512-H4KtxDFmDN8QiTRiGfBySyjMhVaHAJTKB0llGGKZT5jKxtnx9gvEtMWXKtVuRP0NJJP0H6xBPJHNOH7nT18qiQ==
+vuetify@^2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.6.8.tgz#3f4cfa56b7eff4bad1818cd1812b47f6754e140a"
+  integrity sha512-CbJsIGfye++an5/I5ypmYgf74vxt5j0NJ/7UUIDXRYXZsM9YuEpnqo97Ob4LD6QEli1gJa6WXWS8pXLWk0ArPQ==
 
 watchpack-chokidar2@^2.0.1:
   version "2.0.1"
@@ -15944,6 +15959,11 @@ write-file-atomic@^4.0.1:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+"ws@^5.2.0 || ^6.0.0 || ^7.0.0":
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 ws@^6.2.1:
   version "6.2.2"


### PR DESCRIPTION
* Upgrade to Vue 2.7
* Remove  `@vue/composition-api` dependency (no longer required in 2.7)
  * All composables are now imported from Vue directly 
* Remove `@vue/runtime-dom` dependency (Volar has build-in support for 2.7)
* Update Vue version specific libraries 