### PR TITLE
On demand pseudonymization without refetch/parsing

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -55,7 +55,9 @@
         <v-list nav dense>
           <v-list-item class="anonymize">
             <v-list-item-icon>
-              <v-icon>mdi-incognito</v-icon>
+              <v-badge :color="isAnonymous ? 'red' : ''" dot overlap>
+                <v-icon>mdi-incognito</v-icon>
+              </v-badge>
             </v-list-item-icon>
             <div class="anonymize-content">
               <v-list-item-title>Anonymize</v-list-item-title>

--- a/web/src/api/models/file.ts
+++ b/web/src/api/models/file.ts
@@ -16,6 +16,22 @@ export interface FileIndeterminate {
     fullName?: string;
     labels?: string;
   };
+
+  pseudo: {
+    path: string;
+    shortPath: string;
+    fullName?: string;
+    timestamp?: Date;
+    labels?: string;
+  },
+
+  original: {
+    path: string;
+    shortPath: string;
+    fullName?: string;
+    timestamp?: Date;
+    labels?: string;
+  },
 }
 
 interface LoadedFile extends FileIndeterminate {

--- a/web/src/api/stores/api.store.ts
+++ b/web/src/api/stores/api.store.ts
@@ -50,9 +50,9 @@ export const useApiStore = defineStore("api", () => {
 
   // Re-hydrate the API stores when the anonymous value changes.
   watch(
-    () => isAnonymous.value,
+    isAnonymous,
     () => {
-      hydrate();
+      fileStore.anonymize();
     }
   );
 

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -4,7 +4,7 @@ import { shallowRef, computed, nextTick } from "vue";
 import { DATA_URL } from "@/api";
 import { File, ObjMap } from "@/api/models";
 import { useApiStore } from "@/api/stores";
-import { colors, names, uniqueNamesGenerator } from "unique-names-generator";
+import { names, uniqueNamesGenerator } from "unique-names-generator";
 import { useLegend } from "@/composables";
 import { commonFilenamePrefix } from "../utils";
 

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -51,9 +51,10 @@ export const useFileStore = defineStore("files", () => {
 
       // Store pseudo details.
       const pseudoName = randomNameGenerator();
+      const pseudoPath = `${pseudoName}.${filePathExtension}`;
       file.pseudo = {
-        path: `${pseudoName}.${filePathExtension}`,
-        shortPath: file.pseudo.path,
+        path: pseudoPath,
+        shortPath: pseudoPath,
         fullName: pseudoName,
         timestamp: extra.timestamp ? new Date(extra.timestamp.getTime() + timeOffset) : undefined,
         labels: String(labels.indexOf(extra.labels)) ?? "",

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -25,7 +25,7 @@ export const useFileStore = defineStore("files", () => {
   // Parse the files from a CSV string.
   function parse(fileData: d3.DSVRowArray): ObjMap<File> {
     const randomNameGenerator = (): string => uniqueNamesGenerator({
-      dictionaries: [colors, names],
+      dictionaries: [names],
       length: 1
     });
 

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -30,6 +30,7 @@ export const useFileStore = defineStore("files", () => {
     });
 
     const timeOffset = Math.random() * 1000 * 60 * 60 * 24 * 20;
+    const labels: string[] = [];
 
     const filesMap = fileData.map((row: any) => {
       const file = row as File;
@@ -43,6 +44,11 @@ export const useFileStore = defineStore("files", () => {
       file.astAndMappingLoaded = true;
       file.amountOfKgrams = file.amountOfKgrams || file.ast.length;
 
+      // Add the label to the labels list, if it doesn't exist yet.
+      if (!labels.includes(row.label)) {
+        labels.push(extra.labels);
+      }
+
       // Store pseudo details.
       const pseudoName = randomNameGenerator();
       file.pseudo = {
@@ -50,7 +56,7 @@ export const useFileStore = defineStore("files", () => {
         shortPath: "",
         fullName: pseudoName,
         timestamp: extra.timestamp ? new Date(extra.timestamp.getTime() + timeOffset) : undefined,
-        labels: "koekjes",
+        labels: String(labels.indexOf(extra.labels)) ?? "",
       };
 
       // Store original details.
@@ -116,7 +122,10 @@ export const useFileStore = defineStore("files", () => {
       }
     }
 
-    nextTick(() => (apiStore.isLoaded = true));
+    nextTick(() => {
+      files.value = { ...files.value };
+      apiStore.isLoaded = true;
+    });
   }
 
   return {

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -26,7 +26,7 @@ export const useFileStore = defineStore("files", () => {
   function parse(fileData: d3.DSVRowArray): ObjMap<File> {
     const randomNameGenerator = (): string => uniqueNamesGenerator({
       dictionaries: [colors, names],
-      length: 2
+      length: 1
     });
 
     const timeOffset = Math.random() * 1000 * 60 * 60 * 24 * 20;
@@ -52,8 +52,8 @@ export const useFileStore = defineStore("files", () => {
       // Store pseudo details.
       const pseudoName = randomNameGenerator();
       file.pseudo = {
-        path: `/exercise/${pseudoName}.${filePathExtension}`,
-        shortPath: "",
+        path: `${pseudoName}.${filePathExtension}`,
+        shortPath: file.pseudo.path,
         fullName: pseudoName,
         timestamp: extra.timestamp ? new Date(extra.timestamp.getTime() + timeOffset) : undefined,
         labels: String(labels.indexOf(extra.labels)) ?? "",
@@ -73,13 +73,10 @@ export const useFileStore = defineStore("files", () => {
     const files: File[] = Object.fromEntries(filesMap);
 
     // Find the common path in the files.
-    const commonPath = commonFilenamePrefix(Object.values(files), (f) => f.path);
+    const commonPath = commonFilenamePrefix(Object.values(files));
     const commonPathLength = commonPath.length;
-    const commonPseudoPath = commonFilenamePrefix(Object.values(files), (f) => f.pseudo.path);
-    const commonPseudoPathLength = commonPseudoPath.length;
     for (const file of Object.values(files)) {
       file.shortPath = file.path.substring(commonPathLength);
-      file.pseudo.shortPath = file.pseudo.path.substring(commonPseudoPathLength);
       file.original.shortPath = file.shortPath;
     }
 

--- a/web/src/api/utils/file.ts
+++ b/web/src/api/utils/file.ts
@@ -13,18 +13,19 @@ export function fileToTokenizedFile(file: File): TokenizedFile {
 /**
  * Common filename prefix for a given list of files
  * @param files Files
+ * @param getPath Function to extract the path from the file
  * @returns Common prefix for all files.
  */
-export function commonFilenamePrefix(files: File[]): string {
+export function commonFilenamePrefix(files: File[], getPath: (f: File) => string): string {
   if (files.length <= 1) return "";
 
   let index = 0;
   while (
-    files[0].path[index] &&
-    files.every((f) => f.path[index] === files[0].path[index])
+    getPath(files[0])[index] &&
+    files.every((f) => getPath(f)[index] === getPath(files[0])[index])
   ) {
     index++;
   }
 
-  return files[0].path.substring(0, index) ?? "";
+  return getPath(files[0]).substring(0, index) ?? "";
 }

--- a/web/src/api/utils/file.ts
+++ b/web/src/api/utils/file.ts
@@ -16,16 +16,16 @@ export function fileToTokenizedFile(file: File): TokenizedFile {
  * @param getPath Function to extract the path from the file
  * @returns Common prefix for all files.
  */
-export function commonFilenamePrefix(files: File[], getPath: (f: File) => string): string {
+export function commonFilenamePrefix(files: File[]): string {
   if (files.length <= 1) return "";
 
   let index = 0;
   while (
-    getPath(files[0])[index] &&
-    files.every((f) => getPath(f)[index] === getPath(files[0])[index])
+    files[0].path[index] &&
+    files.every((f) => f.path[index] === files[0].path[index])
   ) {
     index++;
   }
 
-  return getPath(files[0]).substring(0, index) ?? "";
+  return files[0].path.substring(0, index) ?? "";
 }

--- a/web/src/api/utils/file.ts
+++ b/web/src/api/utils/file.ts
@@ -13,7 +13,6 @@ export function fileToTokenizedFile(file: File): TokenizedFile {
 /**
  * Common filename prefix for a given list of files
  * @param files Files
- * @param getPath Function to extract the path from the file
  * @returns Common prefix for all files.
  */
 export function commonFilenamePrefix(files: File[]): string {


### PR DESCRIPTION
On demand pseudonymization without refetching the data & parsing the files.

The fix uses the `isLoaded` property to force re-rendering of the main view, which makes sure every component is updated to the new pseudo names. This is not the most performant solution but does not require changing `shallowRef` to `ref` in every component (which causes other performance issues).

Closes #785 