### PR TITLE
Improve Monaco editor performance

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-vue": "^9.3.0",
+    "monaco-editor-webpack-plugin": "^7.0.1",
     "np": "^7.5.0",
     "sass": "<1.33.0",
     "sass-loader": "^13.0.0",

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const webpack = require("webpack");
+const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 
 module.exports = {
   publicPath: "./",
@@ -21,6 +22,7 @@ module.exports = {
         resourceRegExp: /codeTokenizer/,
         contextRegExp: /library/,
       }),
+      new MonacoWebpackPlugin()
     ],
   },
 };


### PR DESCRIPTION
Use the build-in web worker in Monaco to offload expensive tasks to a webworker instead of freezing the main thread. Uses the `monaco-editor-webpack-plugin` to automatically resolve the correct webworker URL.