### PR TITLE
Add some custom renovate configurations

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
-  ]
+    "config:base",
+    "schedule:weekly"
+  ],
+  "rangeStrategy": "update-lockfile",
+  "lockFileMaintenance": { "enabled": true },
+  "timezone": "Europe/Brussels"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,6 @@
   ],
   "rangeStrategy": "update-lockfile",
   "lockFileMaintenance": { "enabled": true },
-  "timezone": "Europe/Brussels"
+  "timezone": "Europe/Brussels",
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
This PR adds some custom configuration to the Renovate config:
- [`schedule:weekly`](https://docs.renovatebot.com/presets-schedule/#scheduleweekly) run renovate weekly on monday morning
- [`rangeStrategy`](https://docs.renovatebot.com/configuration-options/#rangestrategy): Update the lock file when in-range updates are available, otherwise replace for updates out of range.  (Replace:  Replace the range with a newer one if the new version falls outside it, and update nothing otherwise)
- [`lockFileMaintenance`](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) will recreate the lockfile regularly to keep it up to date
- [`timezone`](https://docs.renovatebot.com/configuration-options/#timezone) is used to configure the correct time zone for scheduled updates