### PR TITLE
Fix issue with tooltip on histogram hover

### DIFF
--- a/web/src/components/summary/PairStatHistogram.vue
+++ b/web/src/components/summary/PairStatHistogram.vue
@@ -247,6 +247,7 @@ const draw = (): void => {
     .attr("stroke", "black")
     .attr("stroke-width", 1)
     .attr("stroke-dasharray", "3,3")
+    .attr("pointer-events", "none")
     .attr("z-index", 2)
     .attr("visibility", "hidden");
   const number = histogramChart.select("g")


### PR DESCRIPTION
When hovering over a histogram on the submission detail page the tooltip is sometimes not visible. This PR fixes that issue.