### PR TITLE
Fix showing initials in cluster tags

### DIFF
--- a/web/src/components/clustering/ClusterTags.vue
+++ b/web/src/components/clustering/ClusterTags.vue
@@ -75,16 +75,12 @@ const draw = (): void => {
   groups
     .append("text")
     .text((file) => {
-      if (file.extra.fullName) {
-        const splitName = file.extra.fullName.split(" ");
-        if (splitName.length === 2) {
-          return (splitName[0][0] + splitName[1][0]).toUpperCase();
-        } else {
-          return file.extra.fullName[0].toUpperCase();
-        }
+      const name = file.extrafullName ?? file.shortPath;
+      const splitName = name.split(" ");
+      if (splitName.length === 2) {
+        return (splitName[0][0] + splitName[1][0]).toUpperCase();
       } else {
-        const path = file.shortPath;
-        return path[path.length - 1][0].toUpperCase();
+        return name[0].toUpperCase();
       }
     })
     .attr("stroke", "white")


### PR DESCRIPTION
Previously, if no `fullName` was present, the code would use the last letter of `shortpath`, resulting in python-files (.py) all having `Y` as initial.

This fixes this issue (#887) and also simplifies the code a bit. 