### PR TITLE
Fix 'maximum call stack size exceeded' error when analyzing large files

### DIFF
--- a/lib/src/lib/tokenizer/codeTokenizer.ts
+++ b/lib/src/lib/tokenizer/codeTokenizer.ts
@@ -1,6 +1,7 @@
 import { default as Parser, SyntaxNode } from "tree-sitter";
 import { Region } from "../util/region";
 import { Token, Tokenizer } from "./tokenizer";
+import assert from "assert";
 
 export class CodeTokenizer extends Tokenizer {
   public static supportedLanguages =
@@ -96,7 +97,8 @@ export class CodeTokenizer extends Tokenizer {
       node.endPosition.column
     );
 
-    const location = Region.diff(fullSpan, ...this.getChildrenRegions(node))[0];
+    const location = Region.firstDiff(fullSpan, this.getChildrenRegions(node));
+    assert(location !== null, "There should be at least one diff'ed region");
 
     yield this.newToken("(", location);
 

--- a/lib/src/lib/util/region.ts
+++ b/lib/src/lib/util/region.ts
@@ -88,35 +88,34 @@ export class Region {
   }
 
   /**
-   * This function takes the 'difference' of one region with a list of other regions.
+   * This function takes the first 'difference' of one region with a list of other regions.
    * The 'difference' of a region is every interval [(x1,y1), (x2, y2)] that is only covered by the source region.
    *
    * In this case, this is useful for determining the region a node covers without taking its children into account.
    *
    * Every region that belongs to the diff (that is covered by source, and not by any other) is called a 'good' region.
    * @param source
-   * @param other
+   * @param others
+   * @returns the first 'difference' region, or null if there is none.
    */
-  public static diff(source: Region, ...other: Region[]) : Region[] {
+  public static firstDiff(source: Region, others: Region[]) : Region | null {
     type Point = [number, number]
     const regionToPoints = (r: Region): [Point, Point] => [[r.startRow, r.startCol], [r.endRow, r.endCol]];
     const [startPoint, endPoint] = regionToPoints(source);
 
-    const pointArray = other.map(regionToPoints);
+    const pointArray = others.map(regionToPoints);
     // This map contains all the startpoints mapped to their respective endpoints.
     // This is how we will identify the closing point of this token
     const pointMap = new Map(pointArray);
 
     const points = [startPoint, endPoint, ...pointMap.keys(), ...pointMap.values()];
-    const sortfunc = (a: Point, b: Point): number => a[0] == b[0] ? (a[1] - b[1]) : (a[0] - b[0]);  
+    const sortfunc = (a: Point, b: Point): number => a[0] == b[0] ? (a[1] - b[1]) : (a[0] - b[0]);
     points.sort(sortfunc);
 
     // The "points" array now contains all the points (both opening and closing) sorted by their position.
     // We will traverse this array from left to right (beginning of region to end of region) to evaluate whether
     // a spot is covered by the source region and/or other regions.
 
-
-    const result: Region[] = [];
     // This stack contains all regions that are 'active' or cover this interval
     // (at the current point in the traversal process)
     const stack: Set<Point> = new Set();
@@ -129,16 +128,18 @@ export class Region {
       const p = points[currentIndex];
 
       // Extra boolean to check whether we are currently covering the source interval
-      if(p === startPoint)
+      if(p === startPoint) {
         hasStarted = true;
+      }
 
 
       // If this point is a starting point of a child region
       if(pointMap.has(p)) {
         // If we used to be covered by the source region (hasStarted) and by no child regions (stack size == 0)
         // then this region is 'good'.
-        if(stack.size == 0 && hasStarted)
-          result.push(new Region(...firstPoint!, ...p));
+        if(stack.size == 0 && hasStarted) {
+          return new Region(...firstPoint!, ...p);
+        }
 
         // Register that the current region is covered by a child
         stack.add(pointMap.get(p)!);
@@ -147,17 +148,18 @@ export class Region {
         // If this point is the end point of a region, then we remove the end point of this region from the stack.
         // We also register the current point as the starting point of a 'good' region
         stack.delete(p);
-        if(stack.size == 0 && hasStarted)
+        if(stack.size == 0 && hasStarted) {
           firstPoint = p;
+        }
       }
 
       currentIndex += 1;
     }
 
     if(stack.size == 0) {
-      result.push(new Region(...firstPoint!, ...endPoint));
+      return new Region(...firstPoint!, ...endPoint);
+    } else {
+      return null;
     }
-
-    return result;
   }
 }

--- a/web/src/api/workers/data.worker.ts
+++ b/web/src/api/workers/data.worker.ts
@@ -88,10 +88,10 @@ async function populateFragments(
 
   // Check if a given selection is contained within another selection.
   const isContained = (selection: Selection, region: Region): boolean => {
-    return Region.diff(
+    return Region.firstDiff(
       new Region(selection.startRow, selection.startCol, selection.endRow, selection.endCol),
-      region,
-    ).length === 0;
+      [region],
+    ) === null;
   };
 
   // Convert the paired matches into a map of ranges.


### PR DESCRIPTION
When analyzing large files, the `...list` spread operator can result in a `Maximum call stack size exceeded` error (see #922).

This simplifies the method causing this error a bit and avoids the use of the spread operator by using a list directly. Unfortunately, in the case of #922 the issue itself is not resolved because Node goes out of memory. 