### PR TITLE
Add pairs count to similarity distribution histogram

### DIFF
--- a/web/src/views/Overview.vue
+++ b/web/src/views/Overview.vue
@@ -25,7 +25,7 @@
               <span>{{ language }}</span>
             </v-list-item>
           </v-list>
-          
+
           <template>
             <v-card-title class="info-card-subtitle pt-0 pb-0">
               {{ hasLabels ? legendCount : "No" }} labels detected
@@ -134,7 +134,7 @@
           </v-row>
 
           <overview-barchart
-            :ticks="20"
+            :ticks="40"
             :extra-line="apiStore.cutoff"
           />
         </v-card>


### PR DESCRIPTION
In order to get a better feeling for how to improve the similarity threshold, I've edited the similarity distribution histogram to also show pairs.

Pairs are added as very faint blue bars.
The scale is changed to a log scale because of the high number of pairs.

**Do we want to provide this visualization in the web UI?** This can be behind a toggle button (Include pairs) or in a separate view (which could include extra statistics about the dataset results).

In addition, how can we improve this visualization? I see the following problems:
- Showing pairs as faint blue bars might be confusing, should another color be used?
- What title to put on y-axis? "Similarity frequency"?
- Should the log axis be toggleable?


Below some examples of this change:

## Pyramidal constants - exercise

Without:
![image](https://user-images.githubusercontent.com/3226995/215485108-d6aee3e9-db67-41c6-8b6a-5e762310fd96.png)

With pairs:
![image](https://user-images.githubusercontent.com/3226995/215482271-55882694-8ce2-499f-b614-8147bf33eb81.png)


## Pyramidal constants - evaluation

Without:
![image](https://user-images.githubusercontent.com/3226995/215485223-8f8c984f-99ac-4b69-8fa5-223b7576deca.png)


With pairs:
![image](https://user-images.githubusercontent.com/3226995/215482731-0e692fcd-3ed7-4180-8da9-e3f9df051605.png)

## Plutokiller - exercise

Without:
![image](https://user-images.githubusercontent.com/3226995/215484997-86dc5379-0b7b-4c7d-951e-d580091159ea.png)

With pairs:
![image](https://user-images.githubusercontent.com/3226995/215483398-0aabb4d6-e800-4c4d-bccb-e055963ef8e4.png)

## Highly similar exercise (R1)

Without:
![image](https://user-images.githubusercontent.com/3226995/215484768-5ae0a5d8-c3fb-4500-b7c2-70751ef159b0.png)

With pairs:
![image](https://user-images.githubusercontent.com/3226995/215483553-2396221e-aeec-424c-a30c-8f2461da12c4.png)

## Highly similar exercise (R2)

Without:
![image](https://user-images.githubusercontent.com/3226995/215484678-19bc5fa7-6ddd-49b5-9ee9-dded96f36104.png)

With pairs:
![image](https://user-images.githubusercontent.com/3226995/215483640-53824d0b-1c21-49d9-9031-16ab9180fdad.png)

This last case adds a lot of "explaantion" as to why the threshold is chosen at 25%: it is is the "first" local minimum that Dolos finds. How to improve this threshold selection is for another discussion.