### PR TITLE
Fix similarity value of NaN when files are empty

### DIFF
--- a/lib/src/lib/analyze/pair.ts
+++ b/lib/src/lib/analyze/pair.ts
@@ -69,7 +69,11 @@ export class Pair extends Identifiable {
     this.rightCovered = right.length;
     this.leftTotal = leftFile.kgrams.length;
     this.rightTotal = rightFile.kgrams.length;
-    this.similarity = (this.leftCovered + this.rightCovered) / (this.leftTotal + this.rightTotal);
+    if (this.leftTotal + this.rightTotal > 0) {
+      this.similarity = (this.leftCovered + this.rightCovered) / (this.leftTotal + this.rightTotal);
+    } else {
+      this.similarity = 0;
+    }
   }
 
   private longestCommonSubstring(l: Kgram[], r: Kgram[]): number {

--- a/lib/src/test/dolos.test.ts
+++ b/lib/src/test/dolos.test.ts
@@ -211,3 +211,12 @@ test("should read ZIP-files", async t => {
   t.is(6, pairs.length);
   t.true(pairs[0].similarity > 0.75);
 });
+
+test("empty files should match 0%", async t => {
+  const dolos = new Dolos();
+  const report = await dolos.analyze([new File("file1.js", ""), new File("file2.js", "")]);
+  const pairs = report.allPairs();
+  t.is(0, pairs[0].similarity);
+  t.is(0, pairs[0].overlap);
+  t.is(0, pairs[0].longest);
+});


### PR DESCRIPTION
With the new algorithm to calculate metrics, empty files could possibly result in a similarity of `NaN`. Since this can throw off calculations, we now give these files a similarity of 0.