### PR TITLE
Make timestamp formats consistent

### DIFF
--- a/web/src/components/FileTimestamp.vue
+++ b/web/src/components/FileTimestamp.vue
@@ -18,7 +18,7 @@
 
 <script lang="ts" setup>
 import { File } from "@/api/models";
-import { DateTime } from "luxon";
+import { formatLongDateTime, formatShortDateTime } from "@/util/TimeFormatter";
 import { computed } from "vue";
 
 interface Props {
@@ -29,15 +29,11 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {});
 
-const timestamp = computed(() =>
-  props.file?.extra?.timestamp ?? props.timestamp
+const timestamp = computed(
+  () => props.file?.extra?.timestamp ?? props.timestamp ?? new Date()
 );
-const timeShort = computed(() =>
-  DateTime.fromJSDate(timestamp.value).toLocaleString(DateTime.DATETIME_SHORT)
-);
-const timeLong = computed(() =>
-  DateTime.fromJSDate(timestamp.value).toLocaleString(DateTime.DATETIME_MED)
-);
+const timeShort = computed(() => formatShortDateTime(timestamp.value));
+const timeLong = computed(() => formatLongDateTime(timestamp.value));
 </script>
 
 <style lang="scss" scoped>

--- a/web/src/components/graph/GraphSelectedInfo.vue
+++ b/web/src/components/graph/GraphSelectedInfo.vue
@@ -100,8 +100,8 @@ import { computed, toRef } from "vue";
 import { useCluster } from "@/composables";
 import { File, Legend } from "@/api/models";
 import { Cluster, Clustering } from "@/util/clustering-algorithms/ClusterTypes";
-import { DateTime } from "luxon";
 import { getClusterElements } from "@/util/clustering-algorithms/ClusterFunctions";
+import { formatLongDateTime } from "@/util/TimeFormatter";
 
 interface Props {
   currentClustering: Clustering;
@@ -119,9 +119,7 @@ const { clusterFilesSet, clusterAverageSimilarity } = useCluster(
 // Timestamp of the selected node.
 const selectedNodeTimestamp = computed(() => {
   if (props.selectedNode?.extra.timestamp) {
-    return DateTime.fromJSDate(
-      props.selectedNode.extra.timestamp
-    ).toLocaleString(DateTime.DATETIME_MED);
+    return formatLongDateTime(props.selectedNode.extra.timestamp);
   }
   return null;
 });

--- a/web/src/util/SortingFunctions.ts
+++ b/web/src/util/SortingFunctions.ts
@@ -2,38 +2,59 @@ import { DateTime } from "luxon";
 
 type SortingFunction<T> = (a: T, b: T) => number;
 
-export function chainSort<T>(...sortingFs: SortingFunction<T>[]): SortingFunction<T> {
-  return (a:T, b:T) => {
-    if (sortingFs.length === 0) { return 0; }
+export function chainSort<T>(
+  ...sortingFs: SortingFunction<T>[]
+): SortingFunction<T> {
+  return (a: T, b: T) => {
+    if (sortingFs.length === 0) {
+      return 0;
+    }
 
     for (const sortingF of sortingFs) {
       const result = sortingF(a, b);
-      if (result !== 0) { return result; }
+      if (result !== 0) {
+        return result;
+      }
     }
 
     return 0;
   };
 }
 
-export function booleanSort<T>(predicate: (a: T) => boolean): SortingFunction<T> {
-  return (a: T, b:T) => {
+export function booleanSort<T>(
+  predicate: (a: T) => boolean
+): SortingFunction<T> {
+  return (a: T, b: T) => {
     const resultA = predicate(a);
     const resultB = predicate(b);
 
-    if (resultA && resultB) { return 0; }
+    if (resultA && resultB) {
+      return 0;
+    }
 
-    if (resultA) { return 1; }
+    if (resultA) {
+      return 1;
+    }
 
-    if (resultB) { return -1; }
+    if (resultB) {
+      return -1;
+    }
 
     return 0;
   };
 }
 
-export function reverseSort<T>(sortingF: SortingFunction<T>): SortingFunction<T> {
+export function reverseSort<T>(
+  sortingF: SortingFunction<T>
+): SortingFunction<T> {
   return (a: T, b: T) => -sortingF(a, b);
 }
 
-export function timestampSort<T>(timestampF: (a: T) => Date): SortingFunction<T> {
-  return (a, b) => DateTime.fromJSDate(timestampF(a)) < DateTime.fromJSDate(timestampF(b)) ? -1 : 1;
+export function timestampSort<T>(
+  timestampF: (a: T) => Date
+): SortingFunction<T> {
+  return (a, b) =>
+    DateTime.fromJSDate(timestampF(a)) < DateTime.fromJSDate(timestampF(b))
+      ? -1
+      : 1;
 }

--- a/web/src/util/TimeFormatter.ts
+++ b/web/src/util/TimeFormatter.ts
@@ -15,8 +15,8 @@ export function formatShortDateTime(date: Date): string {
  */
 export function formatLongDateTime(date: Date): string {
   return DateTime.fromJSDate(date).toLocaleString({
-    weekday: "long",
-    month: "long",
+    weekday: "short",
+    month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",

--- a/web/src/util/TimeFormatter.ts
+++ b/web/src/util/TimeFormatter.ts
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import * as d3 from "d3";
 
 /**
  * Convert a Date object to a short date string.
@@ -14,4 +15,124 @@ export function formatShortDateTime(date: Date): string {
  */
 export function formatLongDateTime(date: Date): string {
   return DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_MED);
+}
+
+/**
+ * Convert a Date object to milliseconds part for D3.
+ * @param date Date object to convert
+ */
+export function formatMillisecondPart(date: Date): string {
+  return `.${DateTime.fromJSDate(date).toFormat("SSS")}`;
+}
+
+/**
+ * Covert a Date object to seconds part for D3.
+ * @param date Date object to convert
+ */
+export function formatSecondPart(date: Date): string {
+  return `:${DateTime.fromJSDate(date).toFormat("ss")}`;
+}
+
+/**
+ * Convert a Date object to minutes part for D3.
+ * @param date Date object to convert
+ */
+export function formatMinutePart(date: Date): string {
+  const minuteParts = DateTime.fromJSDate(date).toLocaleParts({
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  return minuteParts
+    .map((p) => p.value)
+    .join("")
+    .trim();
+}
+
+/**
+ * Convert a Date object to hours part.
+ * @param date Date object to convert
+ */
+export function formatHourPart(date: Date): string {
+  const hourParts = DateTime.fromJSDate(date).toLocaleParts({
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return hourParts
+    .map((p) => p.value)
+    .join("")
+    .trim();
+}
+
+/**
+ * Convert a Date object to days part for D3.
+ * @param date Date object to convert
+ */
+export function formatDayPart(date: Date): string {
+  return DateTime.fromJSDate(date).toLocaleString({
+    day: "numeric",
+    month: "short",
+  });
+}
+
+/**
+ * Convert a Date object to months part for D3.
+ * @param date Date object to convert
+ */
+export function formatMonthPart(date: Date): string {
+  return DateTime.fromJSDate(date).toLocaleString({
+    month: "short",
+  });
+}
+
+/**
+ * Convert a Date object to years part for D3.
+ * @param date Date object to convert
+ */
+export function formatYearPart(date: Date): string {
+  return DateTime.fromJSDate(date).toLocaleString({
+    year: "numeric",
+  });
+}
+
+/**
+ * D3 Multiformatter
+ * @param value Value
+ */
+export function multiformat(value: Date | d3.NumberValue): string {
+  let date: Date | null = null;
+
+  // When a date is provided.
+  if (value instanceof Date) {
+    date = value;
+  }
+
+  // Convert the number value to a date if necessary.
+  if (typeof value === "number") {
+    date = new Date(value);
+  }
+
+  // If the date is invalid, return an empty string.
+  if (!date || isNaN(date.getTime())) {
+    return "";
+  }
+
+  if (d3.timeSecond(date) < date) {
+    return formatMillisecondPart(date);
+  } else if (d3.timeMinute(date) < date) {
+    return formatSecondPart(date);
+  } else if (d3.timeHour(date) < date) {
+    return formatMinutePart(date);
+  } else if (d3.timeDay(date) < date) {
+    return formatHourPart(date);
+  } else if (d3.timeMonth(date) < date) {
+    return formatDayPart(date);
+  } else if (d3.timeYear(date) < date) {
+    return formatMonthPart(date);
+  } else if (d3.timeYear(date) >= date) {
+    return formatYearPart(date);
+  }
+
+  return "";
 }

--- a/web/src/util/TimeFormatter.ts
+++ b/web/src/util/TimeFormatter.ts
@@ -14,7 +14,13 @@ export function formatShortDateTime(date: Date): string {
  * @param date Date object to convert
  */
 export function formatLongDateTime(date: Date): string {
-  return DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_MED);
+  return DateTime.fromJSDate(date).toLocaleString({
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 /**

--- a/web/src/util/TimeFormatter.ts
+++ b/web/src/util/TimeFormatter.ts
@@ -1,0 +1,17 @@
+import { DateTime } from "luxon";
+
+/**
+ * Convert a Date object to a short date string.
+ * @param date Date object to convert
+ */
+export function formatShortDateTime(date: Date): string {
+  return DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_SHORT);
+}
+
+/**
+ * Convert a Date object to a long date string.
+ * @param date Date object to convert
+ */
+export function formatLongDateTime(date: Date): string {
+  return DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_MED);
+}


### PR DESCRIPTION
Make timestamp formats consistent across the application.

* A TimeFormatter file contains all functions for formatting timestamps. 
* D3 now uses luxon as well to follow the same conventions and locale.

Fixes #888 