### PR TITLE
Fix submissions ordering on overview page

### DIFF
--- a/web/src/components/clustering/ClustersTable.vue
+++ b/web/src/components/clustering/ClustersTable.vue
@@ -43,6 +43,7 @@ interface Props {
   clusters: Cluster[];
   concise?: boolean;
   disableSorting?: boolean;
+  limit?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {});
@@ -78,7 +79,7 @@ const headers = computed<DataTableHeader[]>(() => {
 // Table items
 // In the format for the Vuetify data-table.
 const items = computed(() => {
-  return props.clusters.map((cluster) => {
+  const clusters = props.clusters.map((cluster) => {
     const files = getClusterElementsArray(cluster);
 
     return {
@@ -89,6 +90,12 @@ const items = computed(() => {
       cluster,
     };
   });
+
+  // Sort clusters by size by default.
+  // This is necessary for the 'limit' prop to work properly.
+  clusters.sort((a, b) => b.size - a.size);
+
+  return props.limit ? clusters.slice(0, props.limit) : clusters;
 });
 
 // Max width of the submissions

--- a/web/src/components/submission/SubmissionsTable.vue
+++ b/web/src/components/submission/SubmissionsTable.vue
@@ -187,6 +187,7 @@ const items = computed(() => {
     }));
 
   // Sort the files by similarity, by default.
+  // This is necessary for the 'limit' prop to work properly.
   items.sort((a, b) => b.similarity - a.similarity);
 
   return props.limit ? items.slice(0, props.limit) : items;

--- a/web/src/components/submission/SubmissionsTable.vue
+++ b/web/src/components/submission/SubmissionsTable.vue
@@ -95,6 +95,7 @@ interface Props {
   order?: boolean;
   concise?: boolean;
   disableSorting?: boolean;
+  limit?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -166,13 +167,14 @@ const footerProps = {
 // In the format for the Vuetify data-table.
 const items = computed(() => {
   // Sort files on submission date.
+  // This is used to determin the order number in the table.
   const sortedFiles = [...props.files].sort((a, b) => {
     if (!a.extra.timestamp) return 1;
     if (!b.extra.timestamp) return -1;
-    return a.extra.timestamp - b.extra.timestamp;
+    return a.extra.timestamp.getTime() - b.extra.timestamp.getTime();
   });
 
-  return props.files
+  const items = props.files
     .map((file) => ({
       id: file.id,
       name: file.extra.fullName ?? file.shortPath,
@@ -183,6 +185,11 @@ const items = computed(() => {
       lines: file.content.split("\n").length ?? 0,
       order: sortedFiles.indexOf(file) + 1,
     }));
+
+  // Sort the files by similarity, by default.
+  items.sort((a, b) => b.similarity - a.similarity);
+
+  return props.limit ? items.slice(0, props.limit) : items;
 });
 
 // When a row is clicked.

--- a/web/src/views/Overview.vue
+++ b/web/src/views/Overview.vue
@@ -145,7 +145,7 @@
           <v-card-title>Submissions</v-card-title>
           <v-card-subtitle>Highlights the most suspicious individual submissions, useful for exams.</v-card-subtitle>
 
-          <submissions-table :files="submissionsOverview" concise disable-sorting />
+          <submissions-table :files="submissionsOverview" :limit="10" concise disable-sorting  />
 
           <v-card-actions>
             <v-spacer />
@@ -205,10 +205,9 @@ const filesCount = computed(() => fileStore.filesActiveList.length);
 
 // Highest similarity pair.
 const highestSimilarityPair = computed<Pair | null>(() => {
-  const pairs = Object.values(pairStore.pairsActive);
+  const pairs = Object.values(pairStore.pairsActive as Pair[]);
   return pairs.reduce(
-    (a: Pair | null, b: Pair) =>
-      (a?.similarity ?? 0) > b.similarity ? a : b,
+    (a: Pair | null, b: Pair) => (a?.similarity ?? 0) > b.similarity ? a : b,
     null
   );
 });
@@ -248,13 +247,12 @@ const language = computed(() => {
 // First x amount of submissions to display.
 // Sorted by highest similarity
 const submissionsOverview = computed(() => {
-  const submissions = fileStore.filesActiveList;
-  return submissions.sort((a, b) => b.similarity - a.similarity).slice(0, 10);
+  return fileStore.filesActiveList;
 });
 
 // First x amount of clusters to display.
 const clustersOverview = computed(() => {
-  return sortedClustering.value.slice(0, 10);
+  return sortedClustering.value;
 });
 
 // Total amount of clusters

--- a/web/src/views/Overview.vue
+++ b/web/src/views/Overview.vue
@@ -163,7 +163,7 @@
           <v-card-title>Clusters</v-card-title>
           <v-card-subtitle>Aggregates submissions in groups, useful for exercises.</v-card-subtitle>
 
-          <clusters-table :clusters="clustersOverview" concise disable-sorting />
+          <clusters-table :clusters="clustersOverview" :limit="10" concise disable-sorting />
 
           <v-card-actions>
             <v-spacer />


### PR DESCRIPTION
The top 10 items that are displayed in the overview page were not properly chosen from the array.

The `SubmissionsTable` does some internal sorting on timestamp in order to determine the order number of the submissions. The overview page also did sorting on similarity, which was not available on the `File` type.

Fixes #890 