### PR TITLE
Add 'View pair' button to graph when applicable

### DIFF
--- a/web/src/api/stores/pair.store.ts
+++ b/web/src/api/stores/pair.store.ts
@@ -116,7 +116,7 @@ export const usePairStore = defineStore("pairs", () => {
     return pairsActiveById.value[id];
   }
 
-  // Get a list of pairs for a given file.
+  // Get a list of pairs for a given list of files.
   function getPairs(file: File): Pair[] {
     return pairsActiveList.value.filter((pair) => pair.leftFile === file || pair.rightFile === file) ?? [];
   }

--- a/web/src/api/stores/pair.store.ts
+++ b/web/src/api/stores/pair.store.ts
@@ -116,7 +116,7 @@ export const usePairStore = defineStore("pairs", () => {
     return pairsActiveById.value[id];
   }
 
-  // Get a list of pairs for a given list of files.
+  // Get a list of pairs for a given file.
   function getPairs(file: File): Pair[] {
     return pairsActiveList.value.filter((pair) => pair.leftFile === file || pair.rightFile === file) ?? [];
   }

--- a/web/src/components/graph/GraphSelectedInfo.vue
+++ b/web/src/components/graph/GraphSelectedInfo.vue
@@ -106,7 +106,6 @@ import { File, Legend } from "@/api/models";
 import { Cluster, Clustering } from "@/util/clustering-algorithms/ClusterTypes";
 import { getClusterElements } from "@/util/clustering-algorithms/ClusterFunctions";
 import { formatLongDateTime } from "@/util/TimeFormatter";
-import { usePairStore } from "@/api/stores";
 
 interface Props {
   currentClustering: Clustering;

--- a/web/src/components/graph/GraphSelectedInfo.vue
+++ b/web/src/components/graph/GraphSelectedInfo.vue
@@ -62,10 +62,7 @@
 
             <v-list-item class="selected-info-list-item">
               <v-icon>mdi-approximately-equal</v-icon>
-              <span
-                >{{ clusterAverageSimilarity.toFixed(2) * 100 }}% average
-                similarity</span
-              >
+              <span>{{ (clusterAverageSimilarity * 100).toFixed(2) }}% average similarity</span>
             </v-list-item>
           </v-list>
 
@@ -77,14 +74,21 @@
 
           <v-card-actions>
             <v-spacer />
-            <v-btn
-              color="primary"
-              text
-              :to="{
-                name: 'Cluster',
-                params: { clusterId: selectedClusterIndex },
-              }"
-            >
+            <v-btn v-if="selectedClusterPair"
+                   text
+                   :to="{
+                      name: 'Pair',
+                      params: { pairId: selectedClusterPair.id }
+                   }">
+              View pair
+              <v-icon right>mdi-chevron-right</v-icon>
+            </v-btn>
+            <v-btn color="primary"
+                   text
+                   :to="{
+                     name: 'Cluster',
+                     params: { clusterId: selectedClusterIndex },
+            }">
               View cluster
               <v-icon right>mdi-chevron-right</v-icon>
             </v-btn>
@@ -102,6 +106,7 @@ import { File, Legend } from "@/api/models";
 import { Cluster, Clustering } from "@/util/clustering-algorithms/ClusterTypes";
 import { getClusterElements } from "@/util/clustering-algorithms/ClusterFunctions";
 import { formatLongDateTime } from "@/util/TimeFormatter";
+import { usePairStore } from "@/api/stores";
 
 interface Props {
   currentClustering: Clustering;
@@ -111,6 +116,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {});
+const pairStore = usePairStore();
 
 const { clusterFilesSet, clusterAverageSimilarity } = useCluster(
   toRef(props, "selectedCluster")
@@ -137,6 +143,15 @@ const selectedClusterIndex = computed(() => {
     getClusterElements(b).size - getClusterElements(a).size;
   const sortedClustering = Array.from(props.currentClustering).sort(sortFn);
   return sortedClustering.indexOf(props.selectedCluster);
+});
+
+// If the cluster contains exactly 1 pair.
+const selectedClusterPair = computed(() => {
+  if (!props.selectedCluster) return null;
+  if (props.selectedCluster.size !== 1) return null;
+
+  const [pair] = props.selectedCluster;
+  return pair;
 });
 </script>
 

--- a/web/src/components/graph/GraphSelectedInfo.vue
+++ b/web/src/components/graph/GraphSelectedInfo.vue
@@ -116,7 +116,6 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {});
-const pairStore = usePairStore();
 
 const { clusterFilesSet, clusterAverageSimilarity } = useCluster(
   toRef(props, "selectedCluster")


### PR DESCRIPTION
Add 'View pair' button to graph when only 2 submissions are in a single cluster.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/6013068/232007212-d870fd99-f19e-4515-9096-9dcfbc8d3c36.png">

Closes #1015 