### PR TITLE
Subtract timestamp offset instead of adding it when running anonymization

### DIFF
--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -191,7 +191,7 @@ export const useFileStore = defineStore("file", () => {
         shortPath: pseudoPath,
         fullName: pseudoName,
         timestamp: extra.timestamp
-          ? new Date(extra.timestamp.getTime() + timeOffset)
+          ? new Date(extra.timestamp.getTime() - timeOffset)
           : undefined,
       };
 
@@ -310,4 +310,3 @@ export const useFileStore = defineStore("file", () => {
     labelFilesCount,
   };
 });
-


### PR DESCRIPTION
Subtract timestamp offset instead of adding it when running anonymization.

Fixes #1104 