### PR TITLE
Fix bug in API job runner where the directory would already exist

### DIFF
--- a/api/app/jobs/analyze_dataset_job.rb
+++ b/api/app/jobs/analyze_dataset_job.rb
@@ -40,7 +40,6 @@ class AnalyzeDatasetJob < ApplicationJob
 
     @mount = Pathname.new Dir.mktmpdir(nil, @mac ? TMPDIR_PATH : nil)
     @output_dir = @mount.join(OUTPUT_DIRNAME)
-    @output_dir.mkdir
   end
 
   def execute(zipfile_path)

--- a/api/test/jobs/analyze_dataset_job_test.rb
+++ b/api/test/jobs/analyze_dataset_job_test.rb
@@ -7,6 +7,7 @@ class AnalyzeDatasetJobTest < ActiveJob::TestCase
 
   test 'run analyze dataset job' do
     AnalyzeDatasetJob.perform_now(@report)
+    assert_empty @report.stderr
     assert_nil @report.error
     assert_equal 'finished', @report.status
     assert @report.all_files_present?


### PR DESCRIPTION
I've also updated the tests to assert that `stderr` is empty, which will result in more meaningful errors when this test fails.