### PR TITLE
Fix share URL not including base url path

### DIFF
--- a/web/src/components/upload/UploadsTableShareDialog.vue
+++ b/web/src/components/upload/UploadsTableShareDialog.vue
@@ -28,7 +28,7 @@ const snackbar = useSnackbar();
 const shareUrl = computed(() => {
   const sharePath = router.resolve(reportShareRoute.value).href;
 
-  const url = new URL(sharePath, window.location.origin);
+  const url = new URL(sharePath, window.location.href);
   return url.toString();
 });
 


### PR DESCRIPTION
The share URL was only using the `window.location`'s `origin` which does not include the `path`. Using the full `href` should fix this issue.

Closes #1129, 