### PR TITLE
Fix anonymization spinner not finishing

### DIFF
--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -236,7 +236,7 @@ export const useFileStore = defineStore("file", () => {
 
   // Anonymize the data.
   function anonymize(): void {
-    apiStore.loading = false;
+    apiStore.loading = true;
     apiStore.loadingText = "Anonymizing files...";
     const isAnonymous = apiStore.isAnonymous;
 
@@ -269,7 +269,7 @@ export const useFileStore = defineStore("file", () => {
       filesById.value = { ...filesById.value };
       pairStore.pairs = { ...pairStore.pairs };
       legend.value = { ...legend.value };
-      apiStore.loading = true;
+      apiStore.loading = false;
     });
   }
 


### PR DESCRIPTION
The `loading` boolean of the store's value was incorrectly set, causing the page to keep showing the spinner while the data was already anonymized.

Closes #1130 