### PR TITLE
Set report name for uploads

### DIFF
--- a/api/app/jobs/analyze_dataset_job.rb
+++ b/api/app/jobs/analyze_dataset_job.rb
@@ -47,6 +47,7 @@ class AnalyzeDatasetJob < ApplicationJob
       '-V', # enable verbose errors
       '-f', 'csv',
       '-o', OUTPUT_DIRNAME,
+      '-n', @dataset.name,
       '/input.zip'
     ]
     cmd += ['-l', @dataset.programming_language] if @dataset.programming_language.present?

--- a/api/test/jobs/analyze_dataset_job_test.rb
+++ b/api/test/jobs/analyze_dataset_job_test.rb
@@ -21,6 +21,15 @@ class AnalyzeDatasetJobTest < ActiveJob::TestCase
     assert_equal 'javascript', @report.reload.dataset.programming_language
   end
 
+  test 'should have correct report name' do
+    assert_nil @report.dataset.programming_language
+
+    AnalyzeDatasetJob.perform_now(@report)
+
+    metadata_name = CSV.parse(@report.reload.metadata.download).filter_map { |k, v, _| v if k == 'reportName' }.first
+    assert_equal @report.dataset.name, metadata_name
+  end
+
   test 'should not overwrite programming language' do
     @report.dataset.update(programming_language: 'python')
 


### PR DESCRIPTION
Report names were not given to the Dolos analysis, so the report name would default to `input`.

This fixes the issue, passing the dataset name as value for the report name.