### PR TITLE
Fix a bug in the plagiarism graph where some links would be too far from each other

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,7 @@
   "version": "2.2.2",
   "main": "dist/index.html",
   "scripts": {
+    "dev": "vue-cli-service serve",
     "serve": "vue-cli-service serve",
     "serve:server": "VUE_APP_MODE=server vue-cli-service serve",
     "build": "vue-cli-service build",

--- a/web/src/composables/d3/graph/simulation.ts
+++ b/web/src/composables/d3/graph/simulation.ts
@@ -29,7 +29,7 @@ function updateGroups(data: Data): void {
 
 export function createSimulation(context: CanvasRenderingContext2D, data: Data): Simulation {
   const distanceMin = 30;
-  const distanceMax = 300;
+  const distanceMax = 30;
 
   const forceLink = d3
     .forceLink<D3Node, D3Edge>(data.edges)
@@ -64,7 +64,7 @@ export function createSimulation(context: CanvasRenderingContext2D, data: Data):
   }
 
   function links(links: D3Edge[]): void {
-    forceLink.links(links.filter(e => e.similarity > .5));
+    forceLink.links(links);
   }
 
   function reheat(): void {


### PR DESCRIPTION
There was a bug where links with a similarity below .5 would not have an associated force. In addition, the maximum distance between linked nodes would be very large.

This PR now enforces that the strongest links always have the minimum distance and that the distance of the weakest links is maximum double that of the strongest link.

While this should already be an improvement, it would be ideal to also have a force repelling clusters (or just other nodes in general) from the area of other clusters. For example this is still a "stable" configuration:
![image](https://github.com/dodona-edu/dolos/assets/3226995/76e6072b-dc64-44a6-a4c1-f760109121d9)


Fixes #1143 