### PR TITLE
Fix infinite update with timeline

### DIFF
--- a/web/src/components/clustering/ClusterTimeSeries.vue
+++ b/web/src/components/clustering/ClusterTimeSeries.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="timeseries" ref="timeseriesElement">
-    <graph-legend :legend.sync="legend" />
+    <graph-legend :legend="legend" readonly />
   </div>
 </template>
 
@@ -225,11 +225,6 @@ watch(
     draw();
   }
 );
-
-// Update the internal legend object when the legend changes.
-watch(legend, (l) => {
-  legend.value = l;
-});
 
 // Watch width changes & update the size.
 watch(width, () => {

--- a/web/src/components/graph/GraphLegend.vue
+++ b/web/src/components/graph/GraphLegend.vue
@@ -6,6 +6,7 @@
     >
       <label>
         <input
+          :disabled="readonly"
           type="checkbox"
           v-model="legendDatum.selected"
           class="legend-checkbox"
@@ -31,9 +32,10 @@ import { useVModel } from "@vueuse/core";
 
 interface Props {
   legend: Legend;
+  readonly?: boolean;
 }
 
-const props = withDefaults(defineProps<Props>(), {});
+const props = withDefaults(defineProps<Props>(), { readonly: false });
 const emit = defineEmits(["update:legend"]);
 const legendValue = useVModel(props, "legend", emit);
 

--- a/web/src/views/analysis/cluster.vue
+++ b/web/src/views/analysis/cluster.vue
@@ -98,7 +98,7 @@
                 node-clickable
                 @click:node="onNodeClick"
               >
-                <graph-legend :legend.sync="legend" />
+                <graph-legend :legend="legend" readonly />
               </graph>
             </v-card-text>
           </v-card>

--- a/web/src/views/analysis/submission.vue
+++ b/web/src/views/analysis/submission.vue
@@ -126,7 +126,7 @@
                     node-clickable
                     @click:node="onNodeClick"
                   >
-                    <graph-legend :legend.sync="legend" />
+                    <graph-legend :legend="legend" readonly />
                   </graph>
                 </div>
               </v-card-text>


### PR DESCRIPTION
This PR fixes a bug in the cluster timeline where the `legend` would infinitely watch & update itself, causing the page to hang.

Fixes #1160  