### PR TITLE
Fix inconsistent lockfile Ruby version in Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ruby:3.1.2
+FROM ruby:3.2.2
 RUN apt-get update -qq && apt-get -y install mariadb-client
 WORKDIR /dolos
 


### PR DESCRIPTION
The dockerfile contained an older Ruby version as the generated lockfile. This PR updates the Ruby version of the docker container to the same version as the lockfile to fix the docker build.