### PR TITLE
Limit CodeQL checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,11 +14,8 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
-    - cron: '33 7 * * 1'
+    - cron: '33 8 * * *'
 
 jobs:
   analyze:
@@ -28,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: [ 'javascript', 'ruby' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed


### PR DESCRIPTION
Since the API project uses Ruby on Rails, I've enabled ruby checks with CodeQL.

CodeQL was giving rate limit errors. Since it often slows down the checking process and has not brought up any major issues, I've set it to run on pushes to the main branch and daily at 8:00.