### PR TITLE
Make async code in core sync

### DIFF
--- a/core/src/algorithm/fingerprintIndex.ts
+++ b/core/src/algorithm/fingerprintIndex.ts
@@ -41,7 +41,7 @@ export class FingerprintIndex {
     this.index = new Map<Hash, SharedFingerprint>();
   }
 
-  public async addFiles(tokenizedFiles: TokenizedFile[]): Promise<Map<Hash, SharedFingerprint>> {
+  public addFiles(tokenizedFiles: TokenizedFile[]): Map<Hash, SharedFingerprint> {
 
     for (const f of tokenizedFiles) {
       assert(!this.files.has(f.id), `This file has already been analyzed: ${f.file.path}`);
@@ -58,7 +58,7 @@ export class FingerprintIndex {
 
       this.files.set(file.id, entry);
 
-      for await (
+      for (
         const { data, hash, start, stop  }
         of this.hashFilter.fingerprints(file.tokens)
       ) {

--- a/core/src/hashing/hashFilter.ts
+++ b/core/src/hashing/hashFilter.ts
@@ -17,11 +17,13 @@ export abstract class HashFilter {
   }
 
 
-  public async *hashTokens(tokens: string[]): AsyncGenerator<[number, string]> {
+  public hashTokens(tokens: string[]): Array<[number, string]> {
+    const hashes: Array<[number, string]> = [];
     for (const token of tokens) {
-      yield [this.hasher.hashToken(token), token];
+      hashes.push([this.hasher.hashToken(token), token]);
     }
+    return hashes;
   }
 
-  public abstract fingerprints(tokens: string[]): AsyncIterableIterator<Fingerprint>;
+  public abstract fingerprints(tokens: string[]): Array<Fingerprint>;
 }

--- a/core/src/hashing/winnowFilter.ts
+++ b/core/src/hashing/winnowFilter.ts
@@ -30,18 +30,19 @@ export class WinnowFilter extends HashFilter {
    *
    * @param tokens The list of tokens to process.
    */
-  public async *fingerprints(tokens: string[]): AsyncIterableIterator<Fingerprint> {
+  public fingerprints(tokens: string[]): Array<Fingerprint> {
     const hash = new RollingHash(this.k);
     let window: string[] = [];
     let filePos: number = -1 * this.k;
     let bufferPos = 0;
     let minPos = 0;
     const buffer: number[] = new Array(this.windowSize).fill(Number.MAX_SAFE_INTEGER);
+    const fingerprints: Array<Fingerprint> = [];
 
     // At the end of each iteration, minPos holds the position of the rightmost
     // minimal hashing in the current window.
     // yield([x,pos]) is called only the first time an instance of x is selected
-    for await (const [hashedToken, token] of this.hashTokens(tokens)) {
+    for (const [hashedToken, token] of this.hashTokens(tokens)) {
       filePos++;
       window = window.slice(-this.k + 1);
       window.push(token);
@@ -68,12 +69,12 @@ export class WinnowFilter extends HashFilter {
         const offset = (minPos - bufferPos - this.windowSize) % this.windowSize;
         const start = filePos + offset;
 
-        yield {
+        fingerprints.push({
           data: this.kgramData ? tokens.slice(start, start + this.k) : null,
           hash: buffer[minPos],
           start,
           stop: start + this.k - 1,
-        };
+        });
 
       } else {
         // Otherwise, the previous minimum is still in this window. Compare
@@ -82,14 +83,15 @@ export class WinnowFilter extends HashFilter {
           minPos = bufferPos;
           const start = filePos + ((minPos - bufferPos - this.windowSize) % this.windowSize);
 
-          yield {
+          fingerprints.push({
             data: this.kgramData ? tokens.slice(start, start + this.k) : null,
             hash: buffer[minPos],
             start,
             stop: start + this.k - 1,
-          };
+          });
         }
       }
     }
+    return fingerprints;
   }
 }

--- a/core/src/test/fragment.test.ts
+++ b/core/src/test/fragment.test.ts
@@ -16,7 +16,7 @@ function createTokenizedSampleFile(): TokenizedFile {
 }
 
 
-test("fragment should fully reconstruct matched kgrams when k > w", async t => {
+test("fragment should fully reconstruct matched kgrams when k > w", t => {
 
   const f1 = createTokenizedSampleFile();
   const f2 = createTokenizedSampleFile();
@@ -24,11 +24,11 @@ test("fragment should fully reconstruct matched kgrams when k > w", async t => {
   const filter = new WinnowFilter(10, 5, true);
 
   const f1Hashes = [];
-  for await (const hash of filter.fingerprints(f1.tokens)) {
+  for (const hash of filter.fingerprints(f1.tokens)) {
     f1Hashes.push(hash);
   }
   const f2Hashes = [];
-  for await (const hash of filter.fingerprints(f2.tokens)) {
+  for (const hash of filter.fingerprints(f2.tokens)) {
     f2Hashes.push(hash);
   }
   t.is(f1Hashes.length, f2Hashes.length);
@@ -60,18 +60,18 @@ test("fragment should fully reconstruct matched kgrams when k > w", async t => {
   t.deepEqual(f1.tokens, fragment.mergedData);
 });
 
-test("fragment should partially reconstruct matched kgrams when k < w", async t => {
+test("fragment should partially reconstruct matched kgrams when k < w", t => {
   const f1 = createTokenizedSampleFile();
   const f2 = createTokenizedSampleFile();
 
   const filter = new WinnowFilter(5, 10, true);
 
   const f1Hashes = [];
-  for await (const hash of filter.fingerprints(f1.tokens)) {
+  for (const hash of filter.fingerprints(f1.tokens)) {
     f1Hashes.push(hash);
   }
   const f2Hashes = [];
-  for await (const hash of filter.fingerprints(f2.tokens)) {
+  for (const hash of filter.fingerprints(f2.tokens)) {
     f2Hashes.push(hash);
   }
   t.is(f1Hashes.length, f2Hashes.length);

--- a/core/src/test/winnowFilter.test.ts
+++ b/core/src/test/winnowFilter.test.ts
@@ -1,7 +1,7 @@
 import test from "ava";
 import { WinnowFilter } from "../hashing/winnowFilter.js";
 
-test("Winnow on comparable files", async t => {
+test("Winnow on comparable files", t => {
   const textA = "abcdefg".split("");
   const textB = "bcdabcefg".split("");
   const k = 2;
@@ -9,12 +9,12 @@ test("Winnow on comparable files", async t => {
   const filter = new WinnowFilter(k, 2);
   const hashes: Map<number, number> = new Map();
   // Build a Map from hashing to position
-  for await (const { hash, start: posA } of filter.fingerprints(textA)) {
+  for (const { hash, start: posA } of filter.fingerprints(textA)) {
     hashes.set(hash, posA);
   }
 
   let overlap = 0;
-  for await (const { hash, start: posB } of filter.fingerprints(textB)) {
+  for (const { hash, start: posB } of filter.fingerprints(textB)) {
     if (hashes.has(hash)) {
       ++overlap;
       const posA = hashes.get(hash) as number;
@@ -26,35 +26,35 @@ test("Winnow on comparable files", async t => {
   t.true(overlap >= 3);
 });
 
-test("no hashes for text shorter than k", async t => {
+test("no hashes for text shorter than k", t => {
   const text = "abcd".split("");
   const filter = new WinnowFilter(5, 1);
   const hashes = [];
 
-  for await (const hash of filter.fingerprints(text)) {
+  for (const hash of filter.fingerprints(text)) {
     hashes.push(hash);
   }
   t.is(0, hashes.length);
 });
 
-test("1 hashing for text length of k", async t => {
+test("1 hashing for text length of k", t => {
   const text = "abcde".split("");
   const filter = new WinnowFilter(5, 1);
   const hashes = [];
 
-  for await (const hash of filter.fingerprints(text)) {
+  for (const hash of filter.fingerprints(text)) {
     hashes.push(hash);
   }
   t.is(1, hashes.length);
 });
 
-test("maximum gap between hashing positions is window size", async t => {
+test("maximum gap between hashing positions is window size", t => {
   const text = "This is a slightly longer text to test multiple hashing values.".split("");
   const windowSize = 3;
   const winnowFilter = new WinnowFilter(5, windowSize);
   let previousPos = 0;
 
-  for await (const { start } of winnowFilter.fingerprints(text)) {
+  for (const { start } of winnowFilter.fingerprints(text)) {
     t.true(start - previousPos <= windowSize);
     previousPos = start;
   }

--- a/lib/src/lib/dolos.ts
+++ b/lib/src/lib/dolos.ts
@@ -159,7 +159,7 @@ export class Dolos {
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const tokenizedFiles = filteredFiles.map(f => this.tokenizer!.tokenizeFile(f));
-    await this.index.addFiles(tokenizedFiles);
+    this.index.addFiles(tokenizedFiles);
 
     return new Report(
       this.options,

--- a/web/src/api/workers/data.worker.ts
+++ b/web/src/api/workers/data.worker.ts
@@ -37,18 +37,18 @@ export function parseFragments(
 }
 
 // Populate the fragments for a given pair.
-export async function populateFragments(
+export function populateFragments(
   pair: Pair,
   metadata: Metadata,
   kgrams: Kgram[]
-): Promise<Pair> {
+): Pair {
   const customOptions = metadata;
   const kmers = kgrams;
 
   const index = new FingerprintIndex(customOptions.kgramLength, customOptions.kgramsInWindow);
   const leftFile = fileToTokenizedFile(pair.leftFile);
   const rightFile = fileToTokenizedFile(pair.rightFile);
-  await index.addFiles([leftFile, rightFile]);
+  index.addFiles([leftFile, rightFile]);
   const reportPair = index.getPair(leftFile, rightFile);
 
   const kmersMap: Map<Hash, Kgram> = new Map();


### PR DESCRIPTION
This is a slight breaking change in the `dolos-core` library that is re-exported in `dolos-lib`:
- `FingerprintIndex#addFiles` is no longer `async` and its result is no longer wrapped in a promise
- `HashFilter#hashTokens` (and its descendant `WinnowFilter#hashTokens`) is no longer `async` and returns an `Array<[number, string]>` istead of an `AsyncIterableIterator`.
- `HashFilter#fingerprints` (and its desendant `WinnowFilter#fingerprints`) is no longer `async` and returns an `Array<Fingerprint>` instead of an `AsyncIterableIterator`.

Closes #1191 