### PR TITLE
Self-host Dolos using docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,31 @@ The analysis results are available in machine readable CSV files and Dolos can b
 
 Try Dolos on <https://dolos.ugent.be>.
 
-## Installation
+## Self-hosting Dolos
 
-If you want to run Dolos locally instead of using [the web app](https://dolos.ugent.be), you can install Dolos your system using npm:
+We provide an instance of the Dolos web app free of charge at <https://dolos.ugent.be>.
+There are no hidden costs and we do not sell, distribute or abuse data in it in any way.
+
+Dolos is fully open-source and you can self-host your own instance.
+The simplest way to self-host dolos, is by using the `docker-compose.yml` configuration in the root of this repository:
+
+1. Ensure [Docker Engine](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) are installed on the system where you will be running Dolos on.
+2. The compose-file is configured to run on localhost only. If you want to host Dolos publicly, change the corresponding configuration in the compose file.
+3. Run `docker-compose build` in this directory to pull and fetch all needed container images.
+4. Run `docker-compose up` to start the services.
+
+If you encounter any issues during the setup, please get in touch.
+
+## Local installation with Dolos CLI
+
+If you want to run the Dolos CLI instead of using [the web app](https://dolos.ugent.be), you can install Dolos CLI your system using npm:
 ```shell
 npm install -g @dodona/dolos
 ```
 
 See [the installation instructions on our website](https://dolos.ugent.be/guide/installation.html) for more complete instructions.
 
-## CLI Usage
+### Usage
 
 Dolos can be launched using the command-line interface, but it is able to
 show the results in your browser.
@@ -53,15 +68,15 @@ Launch Dolos using the following command in your terminal:
 ```shell
 dolos run -f web path/to/your/files/*
 ```
-The above command will launch a web interface with the analysis results at <http://localhost:3000>.
+This will launch a web interface with the analysis results at <http://localhost:3000>.
 
 [More elaborate instructions on how to use Dolos](https://dolos.ugent.be/guide/running.html).
 
-## Documentation
+### Documentation
 
-Visit our web page at <https://dolos.ugent.be>.
+Visit our web page at <https://dolos.ugent.be/docs>.
 
-## Building and developing
+### Building and developing
 
 If you want to build Dolos from source you will need
 [yarn (v1)](https://classic.yarnpkg.com/en/docs/install) because this project

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,10 +1,18 @@
 # syntax=docker/dockerfile:1
 FROM ruby:3.3.0
 RUN apt-get update -qq && apt-get -y install mariadb-client
-WORKDIR /dolos
 
-COPY . /dolos/
-RUN bundle install
+ADD config.ru Gemfile Gemfile.lock Rakefile /dolos/
+WORKDIR /dolos
+RUN bundle install && mkdir log
+
+ADD app/ /dolos/app
+ADD bin/ /dolos/bin
+ADD config/ /dolos/config
+ADD db/ /dolos/db
+ADD lib/ /dolos/lib
+ADD public/ /dolos/public
+ADD test/ /dolos/test
 
 EXPOSE 3000
 

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -318,7 +318,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 3.2.2p53
+   ruby 3.3.0p0
 
 BUNDLED WITH
    2.3.26

--- a/api/README.md
+++ b/api/README.md
@@ -4,6 +4,17 @@ This is the API server for Dolos.
 
 It is a rails application that enables users to upload datasets, which will be analyzed with the Dolos CLI (running in a docker container) and the results will be available on a secret URL.
 
+## Self-host Dolos
+
+We provide a `docker-compose.yml` configuration which you can use to self-host the Dolos web app.
+You can run the Dolos web app by following these instructions:
+1. Ensure [Docker Engine](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) are installed on the system where you will be running Dolos on.
+2. The compose-file is configured to run on localhost only. If you want to host Dolos publicly, change the corresponding configuration in the compose file.
+3. Run `docker-compose build` in this directory to pull and fetch all needed container images.
+4. Run `docker-compose up` to start the services.
+
+If you encounter any issues during the setup, please get in touch.
+
 ## Development
 
 The next steps will guide you through the installation process to start developing:

--- a/api/README.md
+++ b/api/README.md
@@ -4,16 +4,7 @@ This is the API server for Dolos.
 
 It is a rails application that enables users to upload datasets, which will be analyzed with the Dolos CLI (running in a docker container) and the results will be available on a secret URL.
 
-## Self-host Dolos
-
-We provide a `docker-compose.yml` configuration which you can use to self-host the Dolos web app.
-You can run the Dolos web app by following these instructions:
-1. Ensure [Docker Engine](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) are installed on the system where you will be running Dolos on.
-2. The compose-file is configured to run on localhost only. If you want to host Dolos publicly, change the corresponding configuration in the compose file.
-3. Run `docker-compose build` in this directory to pull and fetch all needed container images.
-4. Run `docker-compose up` to start the services.
-
-If you encounter any issues during the setup, please get in touch.
+Refer to the installation instructions in the root of this repository how to self-host a fully working Dolos web app.
 
 ## Development
 
@@ -36,10 +27,11 @@ The flake also provides the command `server:start` to start the database and job
 
 #### Using docker-compose
 
-We have provided a `docker-compose.yml` file that will start the development API server, job worker and MySQL database.
+The `docker-compose.yml` in this directory will start the development API server, job worker and MySQL database.
 You can start this environment with `docker-compose up`.
 
 **Note:** the job worker needs access to spawn new docker containers, the docker daemon socket (`unix:///var/run/docker.sock`) will be mounted in the worker service.
+
 
 #### Using your own environment
 
@@ -73,12 +65,20 @@ docker pull ghcr.io/dodona-ede/dolos:latest
 You can start the job worker with `rails jobs:work`.
 This will start the job worker and will spawn docker containers to analyze datasets once they are uploaded.
 
-
 ### 4. Running the frontend
 
-The frontend is part of the `dolos-web` project that can be found in the `web/` directory of this repository.
+To interact with the API server you should run the `dolos-web` front-end in _server mode_.
+Refer to the instructions in the `web/` directory of this repository.
 
-## Deployment
+## Hosting Dolos API
+
+You can also run the Ruby on Rails application directly without the use of docker-compose.
+
+System requirements:
+- Ruby (see `.ruby-version`)
+- A MariaDB or MySQL database
+- Docker Engine
+- Recommended: a reverse proxy (Nginx, Apache, ...)
 
 This application is deployed using capistrano.
 You can deploy the application with `cap production deploy`.

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -52,5 +52,6 @@ test:
 production:
   <<: *default
   database: dolos
-  username: <%= Rails.application.credentials[:db_user] %>
-  password: <%= Rails.application.credentials[:db_password] %>
+  username: <%= ENV.fetch("DOLOS_API_DATABASE_USERNAME") { Rails.application.credentials[:db_user] } %>
+  password: <%= ENV.fetch("DOLOS_API_DATABASE_PASSWORD") { Rails.application.credentials[:db_password] } %>
+  host: <%= ENV.fetch("DOLOS_API_DATABASE_HOST") { "localhost" } %>

--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -1,6 +1,8 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.hosts = ENV.fetch('DOLOS_API_HOSTS') { 'dolos.ugent.be' }
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -39,7 +41,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = !ENV["DOLOS_API_DISABLE_FORCE_SSL"]
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
@@ -85,6 +87,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   routes.default_url_options = {
-    host: 'dolos.ugent.be'
+    host: ENV.fetch('DOLOS_API_HOSTS') { 'dolos.ugent.be' }
   }
 end

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -6,9 +6,10 @@
 # Read more: https://github.com/cyu/rack-cors
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  debug true
   allow do
     if Rails.env.production?
-      origins Rails.application.config.hosts
+      origins ENV.fetch('DOLOS_API_CORS_ORIGINS') { Rails.application.config.hosts }
     else
       origins "*"
     end

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       VITE_PORT: 8080
       VITE_API_URL: http://localhost:3000
       VITE_MODE: server
-      RAILS_ENV: production
     depends_on:
       - api
     networks:

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,3 +1,4 @@
+name: dolos
 version: "3.9"
 services:
   db:
@@ -5,22 +6,42 @@ services:
     volumes:
       - dolos-db-data:/var/lib/mysql
     environment:
-      MYSQL_ROOT_PASSWORD: dolos
+      MARIADB_ROOT_PASSWORD: dolos
     networks:
       - dolos
   web:
+    build:
+      context: ../web/
+    ports:
+      - "8080:8080"
+    environment:
+      VITE_HOST: 0.0.0.0
+      VITE_PORT: 8080
+      VITE_API_URL: http://localhost:3000
+      VITE_MODE: server
+      RAILS_ENV: production
+    depends_on:
+      - api
+    networks:
+      - dolos
+  api:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails db:prepare && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - dolos-api-storage:/dolos/storage
       - /tmp:/tmp
-      #- .:/dolos
     ports:
       - "3000:3000"
     environment:
+      DOLOS_API_CORS_ORIGINS: http://localhost:8080
+      DOLOS_API_HOSTS: localhost:3000
+      DOLOS_API_DISABLE_FORCE_SSL: true
       DOLOS_API_DATABASE_USERNAME: root
       DOLOS_API_DATABASE_PASSWORD: dolos
       DOLOS_API_DATABASE_HOST: db
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: true
+      SECRET_KEY_BASE_DUMMY: true
     depends_on:
       - worker
     networks:
@@ -30,13 +51,13 @@ services:
     command: bash -c "bundle exec rails jobs:work"
     volumes:
       - dolos-api-storage:/dolos/storage
-      - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
-      #- .:/dolos
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       DOLOS_API_DATABASE_USERNAME: root
       DOLOS_API_DATABASE_PASSWORD: dolos
       DOLOS_API_DATABASE_HOST: db
+      RAILS_ENV: production
     depends_on:
       - db
     networks:

--- a/api/shell.nix
+++ b/api/shell.nix
@@ -2,7 +2,7 @@
 let
   dev = fetchTarball "https://github.com/numtide/devshell/archive/main.tar.gz";
   devshell = pkgs.devshell or (import dev { inherit system; });
-  ruby = pkgs.ruby_3_2;
+  ruby = pkgs.ruby_3_3;
 in
 devshell.mkShell {
   name = "Dolos API server";

--- a/api/shell.nix
+++ b/api/shell.nix
@@ -15,8 +15,6 @@ devshell.mkShell {
   };
   packages = with pkgs; [
     nixpkgs-fmt
-    docker-compose
-    docker
   ];
   language.ruby = {
     package = (pkgs.lowPrio ruby);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - dolos
   web:
     build:
-      context: ../web/
+      context: ./web/
     ports:
       - "8080:8080"
     environment:
@@ -24,7 +24,7 @@ services:
     networks:
       - dolos
   api:
-    build: .
+    build: ./api/
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails db:prepare && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - dolos-api-storage:/dolos/storage
@@ -46,7 +46,7 @@ services:
     networks:
       - dolos
   worker:
-    build: .
+    build: ./api/
     command: bash -c "bundle exec rails jobs:work"
     volumes:
       - dolos-api-storage:/dolos/storage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine3.17
 ARG dolos_version=2.5.0
 
 # node-gyp needs python3 and a compiler to build tree-sitter
-RUN apk --no-cache add python3 build-base &&\
+RUN apk --no-cache add python3 build-base unzip &&\
     npm -g install @dodona/dolos@$dolos_version &&\
     apk --no-cache del python3 build-base
 

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,8 @@ pkgs.devshell.mkShell {
     gnumake
     tree-sitter
     nixpkgs-fmt
+    docker
+    docker-compose
   ];
   env = [{
     name = "PYTHON";


### PR DESCRIPTION
This PR adds a `docker-compose.yml` with instructions to self-host the Dolos web app.