### PR TITLE
Fix tmpdirs not being removed in Dolos API

### DIFF
--- a/api/app/jobs/analyze_dataset_job.rb
+++ b/api/app/jobs/analyze_dataset_job.rb
@@ -53,6 +53,7 @@ class AnalyzeDatasetJob < ApplicationJob
     cmd += ['-l', @dataset.programming_language] if @dataset.programming_language.present?
     docker_options = {
       Cmd: cmd,
+      User: Process.euid.to_s,
       Image: DOLOS_IMAGE,
       name: "dolos-#{@report.id}",
       NetworkDisabled: true,

--- a/api/app/jobs/analyze_dataset_job.rb
+++ b/api/app/jobs/analyze_dataset_job.rb
@@ -161,7 +161,7 @@ class AnalyzeDatasetJob < ApplicationJob
 
   def finalize
     # remove path on file system used as temporary working directory for analyzing the dataset
-    FileUtils.remove_entry_secure(@mount)
+    FileUtils.remove_entry_secure(@mount, verbose: true)
     @mount = nil
   end
 

--- a/api/app/jobs/analyze_dataset_job.rb
+++ b/api/app/jobs/analyze_dataset_job.rb
@@ -161,7 +161,7 @@ class AnalyzeDatasetJob < ApplicationJob
 
   def finalize
     # remove path on file system used as temporary working directory for analyzing the dataset
-    FileUtils.remove_entry_secure(@mount, verbose: true)
+    FileUtils.remove_entry_secure(@mount)
     @mount = nil
   end
 

--- a/api/app/models/dataset.rb
+++ b/api/app/models/dataset.rb
@@ -18,6 +18,8 @@
 class Dataset < ApplicationRecord
   include Tokenable
 
+  MAX_ZIP_SIZE = 10.megabytes
+
   token_generator :token
 
   has_one_attached :zipfile
@@ -26,7 +28,7 @@ class Dataset < ApplicationRecord
   validates :zipfile,
             attached: true,
             content_type: 'application/zip',
-            size: { less_than: 10.megabytes }
+            size: { less_than: MAX_ZIP_SIZE }
 
   before_create :generate_token
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ RUN apk --no-cache add python3 build-base unzip &&\
     npm -g install @dodona/dolos@$dolos_version &&\
     apk --no-cache del python3 build-base
 
-EXPOSE 3000/tcp
+USER node
 WORKDIR /dolos
+EXPOSE 3000/tcp
 ENTRYPOINT [ "dolos" ]


### PR DESCRIPTION
We've had some issues with the `/tmp` directory filling up with the result files that were not removed at the end of an analysis, ultimately filling up the storage space (and causing Dolos to give 500 errors).

This was caused by dolos running as `root` in the container. The files that were created during the analysis could therefore not be removed by the webserver because it did not have the correct permissions. The error was hidden by another bug where the argument `verbose: true` to the method `remove_entry_safe`, which was actually interpreted as `force = true` which ignores errors.

This PR changes the default user of the Dolos docker container to `node` and sets the container uid to that matching the current user running the webserver. The resulting files should be owned by the current user and should be removed again.

I have pushed this change with `ghcr.io/dodona-edu/dolos:2.5.1-1` to let the CI succeed.