### PR TITLE
Clean up API routes, responses and errors

### DIFF
--- a/api/app/controllers/datasets_controller.rb
+++ b/api/app/controllers/datasets_controller.rb
@@ -1,25 +1,9 @@
 class DatasetsController < ApplicationController
-  before_action :set_dataset, only: %i[show analyze destroy]
+  before_action :set_dataset, only: %i[show]
 
   # GET /datasets/1
   def show
     render json: @dataset
-  end
-
-  # POST /datasets/1/analyze
-  def analyze
-    @report = Report.new(dataset: @dataset)
-
-    if @report.save
-      render json: @report, status: :created, location: @report
-    else
-      render json: @report.errors, status: :unprocessable_entity
-    end
-  end
-
-  # DELETE /datasets/1
-  def destroy
-    @dataset.destroy
   end
 
   private
@@ -27,10 +11,5 @@ class DatasetsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_dataset
     @dataset = Dataset.find(params[:id])
-  end
-
-  # Only allow a list of trusted parameters through.
-  def dataset_params
-    params.require(:dataset).permit(:zipfile, :name, :programming_language)
   end
 end

--- a/api/app/controllers/reports_controller.rb
+++ b/api/app/controllers/reports_controller.rb
@@ -8,8 +8,7 @@ class ReportsController < ApplicationController
 
   # POST /reports
   def create
-    @dataset = Dataset.new(dataset_params)
-    @report = Report.new(dataset: @dataset)
+    @report = Report.new(dataset_attributes: dataset_params)
     if @report.save
       render json: @report, status: :created, location: @report
     else
@@ -35,11 +34,6 @@ class ReportsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_report
     @report = Report.find(params[:id])
-  end
-
-  # Only allow a list of trusted parameters through.
-  def report_params
-    params.require(:report).permit(:dataset)
   end
 
   def dataset_params

--- a/api/app/models/dataset.rb
+++ b/api/app/models/dataset.rb
@@ -21,9 +21,21 @@ class Dataset < ApplicationRecord
             content_type: 'application/zip',
             size: { less_than: MAX_ZIP_SIZE }
 
+  validates :name, presence: true, length: { minimum: 3, maximum: 255 }
+
+  before_validation :ensure_name
+
   def purge_files!
     return unless zipfile.attached?
 
     zipfile.purge
+  end
+
+  private
+
+  def ensure_name
+    return unless zipfile.attached?
+
+    self.name ||= zipfile.filename.base
   end
 end

--- a/api/app/models/report.rb
+++ b/api/app/models/report.rb
@@ -39,9 +39,16 @@ class Report < ApplicationRecord
 
   enum :status, { unknown: 0, queued: 1, running: 2, failed: 3, error: 4, finished: 5, purged: 6 }
 
+  validates_associated :dataset, on: :create
+  accepts_nested_attributes_for :dataset
+
   after_create :queue_analysis
 
   delegate :name, to: :dataset
+
+  def html_url
+    "#{Rails.configuration.front_end_base_url}#{Rails.configuration.front_end_html_path}#{id}"
+  end
 
   def queue_analysis
     return if finished?

--- a/api/app/serializers/report_serializer.rb
+++ b/api/app/serializers/report_serializer.rb
@@ -19,11 +19,7 @@
 #  index_reports_on_dataset_id  (dataset_id)
 #
 class ReportSerializer < ApplicationSerializer
-  attributes :error, :exit_status, :memory, :run_time, :status, :stderr, :stdout, :name, :html_url
+  attributes :error, :exit_status, :status, :stderr, :stdout, :name, :html_url
 
   has_one :dataset
-
-  def html_url
-    "#{Rails.configuration.front_end_base_url}#{Rails.configuration.front_end_html_path}#{id}"
-  end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -4,11 +4,7 @@ Rails.application.routes.draw do
       get 'data/:file', to: 'reports#data', as: 'data'
     end
   end
-  resources :datasets, except: %i[index update create] do
-    member do
-      post 'analyze'
-    end
-  end
+  resources :datasets, only: %i[show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/api/test/controllers/datasets_controller_test.rb
+++ b/api/test/controllers/datasets_controller_test.rb
@@ -10,24 +10,4 @@ class DatasetsControllerTest < ActionDispatch::IntegrationTest
     get dataset_url(@dataset), as: :json
     assert_response :success
   end
-
-  test 'should analyze dataset' do
-    assert_enqueued_jobs 1 do
-      assert_difference('Report.count') do
-        post analyze_dataset_url(@dataset), as: :json
-        assert_response :created
-      end
-    end
-
-    report = Report.order(:created_at).last
-    assert_equal 'queued', report.status
-  end
-
-  test 'should destroy dataset' do
-    assert_difference('Dataset.count', -1) do
-      delete dataset_url(@dataset), as: :json
-    end
-
-    assert_response :no_content
-  end
 end


### PR DESCRIPTION
- Remove some unused routes
- Simplify how associated datasets are saved, this now also results in better error messages
- If `dataset[name]` is not given, the name will default to the zipfile name
