### PR TITLE
Fix npm not passing arguments in web Dockerfile

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -16,4 +16,4 @@ EXPOSE 8080/tcp
 
 RUN npm run build
 
-CMD npm run preview --host "$VITE_HOST" --port "$VITE_PORT" --strictPort
+CMD npm run preview -- --host "$VITE_HOST" --port "$VITE_PORT" --strictPort


### PR DESCRIPTION
Since the fix to `npm` (#1438), the docker-compose.yml was broken because it handles arguments different from yarn.

This PR fixes this issue, closing #1459 