### PR TITLE
Wait for analysis job to complete when report is shared

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MYSQL_ROOT_PASSWORD: dolos
     networks:
       - dolos
-  web:
+  api:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails db:prepare && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:

--- a/web/src/components/FileTimestamp.vue
+++ b/web/src/components/FileTimestamp.vue
@@ -23,7 +23,7 @@ import { computed } from "vue";
 
 interface Props {
   file?: File;
-  timestamp?: Date;
+  timestamp?: Date | string;
   long?: boolean;
 }
 

--- a/web/src/components/layout/PageError.vue
+++ b/web/src/components/layout/PageError.vue
@@ -2,11 +2,19 @@
   <div class="page-error">
     <h2>Oops! Something went wrong.</h2>
     <p>{{ message }}</p>
+    <v-btn-group v-if="isServer">
+      <v-btn :to="{ name: 'Upload' }">
+        Go to upload form
+      </v-btn>
+    </v-btn-group>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { computed } from "vue";
+import { useAppMode } from "@/composables/useAppMode";
+
+const { isServer } = useAppMode();
 
 interface Props {
   error: Error | string;

--- a/web/src/components/layout/PageNavbar.vue
+++ b/web/src/components/layout/PageNavbar.vue
@@ -99,7 +99,7 @@ const display = useDisplay();
 const drawerValue = useVModel(props, "drawer", emit);
 const settingsValue = useVModel(props, "settings", emit);
 const shareDialog = ref(false);
-const downloadDatasetUrl = computed(() => currentReport.value?.response?.dataset?.zipfile);
+const downloadDatasetUrl = computed(() => currentReport.value?.datasetURL);
 const { currentReport } = storeToRefs(useReportsStore());
 </script>
 

--- a/web/src/components/upload/UploadFormCard.vue
+++ b/web/src/components/upload/UploadFormCard.vue
@@ -175,6 +175,7 @@ const onSubmit = async (): Promise<void> => {
 
       // Set the report as active.
       reportActiveId.value = report.id;
+      step.value = 3;
     } catch (e: any) {
       if (e.code == "ERR_NETWORK") {
         handleError("Could not connect to the API.");
@@ -230,7 +231,7 @@ const startPolling = (reportId: string): void => {
 
       // If the report is the active report
       // apply some changes to the form UI.
-      if (report === reportActive.value) {
+      if (report.id === reportActive.value?.id) {
         if (report.status === "finished") {
           // Go to the results page.
           step.value = 4;
@@ -258,8 +259,8 @@ watch(
   () => reports.reports,
   (reports) => {
     for (const report of reports) {
-      if (report.status === "queued" || report.status === "running") {
-        startPolling(report.id);
+      if (!report.hasFinalStatus()) {
+         startPolling(report.id);
       }
     }
   },
@@ -287,7 +288,7 @@ watch(
           <v-alert v-if="error" class="mb-4" variant="tonal" type="error" density="compact">
             {{ error }}
           </v-alert>
-          <v-textarea readonly rows="15" :model-value="stderr" />
+          <v-textarea v-if="stderr" readonly :rows="Math.min(15, stderr?.split('\n').length)" :model-value="stderr" />
 
           </div>
 

--- a/web/src/components/upload/UploadStatus.vue
+++ b/web/src/components/upload/UploadStatus.vue
@@ -8,23 +8,23 @@ const props = defineProps<Props>();
 </script>
 
 <template>
-  <v-chip v-if="props.status === 'queued'" color="warning" small>
+  <v-chip v-if="props.status === 'queued'" color="warning" size="small">
     Queued
   </v-chip>
-  <v-chip v-else-if="props.status === 'running'" color="info" small>
+  <v-chip v-else-if="props.status === 'running'" color="info" size="small">
     Running
   </v-chip>
-  <v-chip v-else-if="props.status === 'finished'" color="success" small>
+  <v-chip v-else-if="props.status === 'finished'" color="success" size="small">
     Finished
   </v-chip>
-  <v-chip v-else-if="props.status === 'failed'" color="error" small>
+  <v-chip v-else-if="props.status === 'failed'" color="error" size="small">
     Failed
   </v-chip>
-  <v-chip v-else-if="props.status === 'error'" color="error" small>
+  <v-chip v-else-if="props.status === 'error'" color="error" size="small">
     Error
   </v-chip>
-  <v-chip v-else-if="props.status === 'deleted'" color="grey" small>
+  <v-chip v-else-if="props.status === 'deleted'" color="grey" size="small">
     Deleted
   </v-chip>
-  <v-chip v-else color="grey" small> Unknown </v-chip>
+  <v-chip v-else color="grey" size="small"> Unknown </v-chip>
 </template>

--- a/web/src/components/upload/UploadsTable.vue
+++ b/web/src/components/upload/UploadsTable.vue
@@ -33,16 +33,14 @@ const headers = computed<any>(() => [
 // Table items
 // In the format for the Vuetify data-table.
 const items = computed(() =>
-  reports.reports.map((report) => {
-    console.log(report);
-    return {
+  reports.reports.map((report) => ({
     name: report.name,
     date: report.date,
     status: report.status,
     report: report,
     isFromSharing: report.fromSharing,
     done: report.hasFinalStatus(),
-  }})
+  }))
 );
 
 const selectedReportId = ref<string | undefined>();
@@ -60,19 +58,19 @@ const shareDialog = ref(false);
 
 // Open the dialog for a specific report.
 const openInfoDialog = (e: Event, value: any): void => {
-  selectedReportId.value = value.item.report.reportId;
+  selectedReportId.value = value.item.report.id;
   infoDialog.value = true;
 };
 
 // Open the dialog for deleting a specific report.
 const openDeleteDialog = (item: any): void => {
-  selectedReportId.value = item.report.reportId;
+  selectedReportId.value = item.report.id;
   deleteDialog.value = true;
 };
 
 // Open the dialog for sharing a specific report.
 const openShareDialog = (item: any): void => {
-  selectedReportId.value = item.report.reportId;
+  selectedReportId.value = item.report.id;
   shareDialog.value = true;
 };
 </script>

--- a/web/src/components/upload/UploadsTable.vue
+++ b/web/src/components/upload/UploadsTable.vue
@@ -33,18 +33,16 @@ const headers = computed<any>(() => [
 // Table items
 // In the format for the Vuetify data-table.
 const items = computed(() =>
-  reports.reports.map((report) => ({
+  reports.reports.map((report) => {
+    console.log(report);
+    return {
     name: report.name,
-    date: new Date(report.date),
+    date: report.date,
     status: report.status,
     report: report,
-    isFromSharing: report.isFromSharing,
-    done:
-      report.status === "error" ||
-      report.status === "failed" ||
-      report.status === "finished" ||
-      report.status === "deleted",
-  }))
+    isFromSharing: report.fromSharing,
+    done: report.hasFinalStatus(),
+  }})
 );
 
 const selectedReportId = ref<string | undefined>();

--- a/web/src/components/upload/UploadsTableDeleteDialog.vue
+++ b/web/src/components/upload/UploadsTableDeleteDialog.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { UploadReport } from "@/types/uploads/UploadReport";
+import { Report } from "@/types/uploads/UploadReport";
 import { useVModel } from "@vueuse/core";
 import { ref } from "vue";
 import { useSnackbar } from "../util/snackbar/useSnackbar";
@@ -8,7 +8,7 @@ import { useReportsStore } from "@/stores";
 
 type Props = {
   open: boolean;
-  report: UploadReport;
+  report: Report;
 };
 const props = withDefaults(defineProps<Props>(), {
   open: false,
@@ -32,8 +32,8 @@ const confirm = async (): Promise<void> => {
   try {
     // Attempt to delete the upload.
     // Only delete the upload if a report id is present and the report is not already deleted.
-    if (props.report.reportId && props.report.status !== "deleted") {
-      await axios.delete(reports.getReportUrlById(props.report.reportId));
+    if (props.report.id && props.report.status !== "deleted") {
+      await axios.delete(reports.getReportUrlById(props.report.id));
     }
 
     // Close the dialog.
@@ -58,7 +58,7 @@ const confirm = async (): Promise<void> => {
     loading.value = false;
 
     // Delete the upload from local storage.
-    reports.deleteReportById(props.report.reportId);
+    reports.deleteReportById(props.report.id);
   }
 };
 </script>

--- a/web/src/components/upload/UploadsTableInfoDialog.vue
+++ b/web/src/components/upload/UploadsTableInfoDialog.vue
@@ -1,13 +1,13 @@
 <script lang="ts" setup>
 import { useReportsStore } from "@/stores";
-import { UploadReport } from "@/types/uploads/UploadReport";
+import { Report } from "@/types/uploads/UploadReport";
 import { useVModel } from "@vueuse/core";
 import { DateTime } from "luxon";
 import { computed } from "vue";
 
 type Props = {
   open: boolean;
-  report: UploadReport;
+  report: Report;
 };
 const props = withDefaults(defineProps<Props>(), {
   open: false,
@@ -17,7 +17,7 @@ const open = useVModel(props, "open", emit);
 const reports = useReportsStore();
 
 const reportRoute = computed(() =>
-  reports.getReportRouteById(props.report.reportId)
+  reports.getReportRouteById(props.report.id)
 );
 const reportDate = computed(() =>
   DateTime.fromISO(props.report.date ?? "").toLocaleString(

--- a/web/src/components/upload/UploadsTableInfoDialog.vue
+++ b/web/src/components/upload/UploadsTableInfoDialog.vue
@@ -150,6 +150,17 @@ const isDone = computed(
           <v-icon end>mdi-share-variant</v-icon>
         </v-btn>
 
+        <!-- Download ZIP -->
+        <v-btn
+            variant="text"
+            color="primary"
+            v-if="props.report.datasetURL"
+            :href="props.report.datasetURL"
+        >
+          Dataset
+          <v-icon end>mdi-download</v-icon>
+        </v-btn>
+
         <v-spacer />
 
         <!-- View results -->

--- a/web/src/components/upload/UploadsTableShareDialog.vue
+++ b/web/src/components/upload/UploadsTableShareDialog.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { UploadReport } from "@/types/uploads/UploadReport";
+import { Report } from "@/types/uploads/UploadReport";
 import { useVModel } from "@vueuse/core";
 import { computed } from "vue";
 import { useSnackbar } from "../util/snackbar/useSnackbar";
@@ -8,7 +8,7 @@ import { useRouter } from "vue-router";
 
 type Props = {
   open: boolean;
-  report: UploadReport;
+  report: Report;
 };
 const props = withDefaults(defineProps<Props>(), {
   open: false,
@@ -18,7 +18,7 @@ const router = useRouter();
 const reports = useReportsStore();
 
 const reportShareRoute = computed(() =>
-  reports.getReportShareRouteById(props.report.reportId)
+  reports.getReportShareRouteById(props.report.id)
 );
 
 const open = useVModel(props, "open", emit);

--- a/web/src/composables/useAppMode.ts
+++ b/web/src/composables/useAppMode.ts
@@ -13,7 +13,7 @@ export function useAppMode() {
   // URL to the report.
   const reportUrl = computed(() => {
     if (import.meta.env.VITE_MODE === "server") {
-      if (reports.currentReport) {
+      if (reports.currentReport?.hasFinalStatus()) {
         return reports.currentReport.url;
       } else {
         return undefined;

--- a/web/src/composables/useAppMode.ts
+++ b/web/src/composables/useAppMode.ts
@@ -14,7 +14,7 @@ export function useAppMode() {
   const reportUrl = computed(() => {
     if (import.meta.env.VITE_MODE === "server") {
       if (reports.currentReport) {
-        return reports.getReportUrlById(reports.currentReport.reportId);
+        return reports.currentReport.url;
       } else {
         return undefined;
       }

--- a/web/src/stores/reports.store.ts
+++ b/web/src/stores/reports.store.ts
@@ -17,12 +17,13 @@ export const useReportsStore = defineStore("reports", () => {
   });
 
   function findNextSlug(name: string) {
-    let slug = slugify(name, { lower: true });
+    const base = slugify(name, { lower: true });
+    let slug = base;
 
     let i = 1;
     while (reports.value.find((r) => r.slug === slug)) {
         i += 1;
-        slug = `${slug}-${i}`;
+        slug = `${base}-${i}`;
     }
 
     return slug;
@@ -62,7 +63,7 @@ export const useReportsStore = defineStore("reports", () => {
 
     let report;
     const existing = reports.value.findIndex((r) => r.id === reportId);
-    if (existing) {
+    if (existing >= 0) {
       const previous = reports.value[existing];
       report = Report.fromResponse(response.data, previous.slug, previous.fromSharing);
       reports.value[existing] = report;

--- a/web/src/types/uploads/UploadReport.ts
+++ b/web/src/types/uploads/UploadReport.ts
@@ -41,14 +41,14 @@ export class Report {
   }
 
   public hasFinalStatus() {
-    return this.status !== "running" && this.status !== "queued";
+    return this.status === "finished" || this.status === "error" || this.status === "failed";
   }
 
   static fromResponse(response: Record<string, any>, slug?: string, fromSharing?: boolean): Report {
     return new Report(
       response.id,
       response.name,
-      response.date,
+      response.created_at,
       response.status,
       response.url,
       response.dataset?.zipfile,

--- a/web/src/types/uploads/UploadReportStatus.ts
+++ b/web/src/types/uploads/UploadReportStatus.ts
@@ -4,4 +4,5 @@ export type UploadReportStatus =
   | "failed"
   | "error"
   | "finished"
-  | "deleted";
+  | "deleted"
+  | "api_error";

--- a/web/src/util/TimeFormatter.ts
+++ b/web/src/util/TimeFormatter.ts
@@ -5,16 +5,18 @@ import * as d3 from "d3";
  * Convert a Date object to a short date string.
  * @param date Date object to convert
  */
-export function formatShortDateTime(date: Date): string {
-  return DateTime.fromJSDate(date).toLocaleString(DateTime.DATETIME_SHORT);
+export function formatShortDateTime(date: Date | string): string {
+    const dateTime = date instanceof Date ? DateTime.fromJSDate(date) : DateTime.fromISO(date);
+    return dateTime.toLocaleString(DateTime.DATETIME_SHORT);
 }
 
 /**
  * Convert a Date object to a long date string.
  * @param date Date object to convert
  */
-export function formatLongDateTime(date: Date): string {
-  return DateTime.fromJSDate(date).toLocaleString({
+export function formatLongDateTime(date: Date | string): string {
+  const dateTime = date instanceof Date ? DateTime.fromJSDate(date) : DateTime.fromISO(date);
+  return dateTime.toLocaleString({
     weekday: "short",
     month: "short",
     day: "numeric",

--- a/web/src/views/upload/share.vue
+++ b/web/src/views/upload/share.vue
@@ -6,42 +6,54 @@ import { useRoute, useRouter } from "vue-router";
 
 const router = useRouter();
 const route = useRoute();
-const error = ref(null);
+const error = ref<string | undefined>();
+const task = ref<string>("Fetching report info")
 const reports = useReportsStore();
 
 // Fetch the report from the server and add it to the
 onMounted(async () => {
   const reportId = route.params.reportId as string;
   // Check if the report id is already present.
-  const report = reports.getReportById(reportId);
+  let report = reports.getReportById(reportId);
 
-  // If the report reference does not exist, generate a new one.
-  if (!report) {
-
-    try {
+  try{
+    // If the report reference does not exist, generate a new one.
+    if (!report) {
       // Fetch the report from the server
-      const report = await reports.reloadReport(reportId);
-
-      // Wait until status is final
-      while (!report.hasFinalStatus()) {
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        await reports.reloadReport(reportId);
-      }
-
-    } catch (err: any) {
-      error.value = err.message ?? "Unknown error";
-      return;
+      report = await reports.reloadReport(reportId);
     }
+
+    // Wait until status is final
+    while (!report.hasFinalStatus()) {
+      if (report.status === "queued") {
+        task.value = "Waiting for job to start";
+      } else if (report.status === "running") {
+        task.value = "Waiting for job to complete";
+      }
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      report = await reports.reloadReport(reportId);
+    }
+
+
+  } catch (err: any) {
+    error.value = err.message ?? "Unknown error";
+    return;
   }
-  const reportRoute = reports.getReportRouteById(reportId);
-  // Go to the report.
-  router.push(reportRoute);
+
+  if (report.status === "failed" || report.status === "error") {
+    error.value = report.error ?? "Unknown error";
+  } else {
+    const reportRoute = reports.getReportRouteById(reportId);
+    // Go to the report.
+    router.push(reportRoute);
+  }
+
 });
 </script>
 
 <template>
   <div>
     <page-error v-if="error" :error="error" />
-    <page-loading v-else text="Fetching report..." />
+    <page-loading v-else :text="task" />
   </div>
 </template>


### PR DESCRIPTION
This PR adds functionality to wait for a report to finish when visiting a report's share URL.

This allows other applications to immediately redirect users to this share URL after submitting a new analysis, without waiting for it to finish.