### PR TITLE
Fix bug where navigating back would fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7058,6 +7058,7 @@
     "parsers": {
       "name": "@dodona/dolos-parsers",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "nan": "^2.19.0"

--- a/web/src/components/layout/PageSidebar.vue
+++ b/web/src/components/layout/PageSidebar.vue
@@ -6,7 +6,7 @@
   >
     <template v-if="props.variant === 'analysis'">
       <v-list v-if="isServer" nav density="compact">
-        <v-list-item  :to="{ name: 'Upload' }" link exact>
+        <v-list-item  :to="{ name: 'Upload' }" target="_blank" link exact>
           <template #prepend>
             <v-icon>mdi-chevron-left</v-icon>
           </template>


### PR DESCRIPTION
Navigating back to the upload page from a report would fail, this fixes that issue by opening the upload page in a new tab.