### PR TITLE
Fix hosting Dolos publicly on https using docker-compose

### DIFF
--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -1,9 +1,12 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  config.hosts = ENV.fetch('DOLOS_API_HOSTS') { 'dolos.ugent.be' }
 
+  config.dolos_api_url = URI.parse(ENV.fetch('DOLOS_API_URL') { 'https://dolos.ugent.be/api' })
   config.front_end_base_url = ENV.fetch('DOLOS_API_FRONT_END_URL') { 'https://dolos.ugent.be/server' }
+
+  config.hosts = ENV.fetch('DOLOS_API_HOSTS') { config.dolos_api_url.host }
+
 
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -43,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = !ENV["DOLOS_API_DISABLE_FORCE_SSL"]
+  config.force_ssl = !ENV.fetch("DOLOS_API_DISABLE_FORCE_SSL") { config.dolos_api_url.scheme == 'http' }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
@@ -88,7 +91,12 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Set base url
+  config.relative_url_root = config.dolos_api_url.path
+
   routes.default_url_options = {
-    host: ENV.fetch('DOLOS_API_HOSTS') { 'dolos.ugent.be' }
+    host: ENV.fetch('DOLOS_API_HOSTS') { config.dolos_api_url.host },
+    protocol: config.dolos_api_url.scheme,
+    port: config.dolos_api_url.port,
   }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,7 @@ services:
       - "3000:3000"
     environment:
       DOLOS_API_FRONT_END_URL: http://localhost:8080
-      DOLOS_API_HOSTS: localhost:3000
-      DOLOS_API_DISABLE_FORCE_SSL: true
+      DOLOS_API_URL: http://localhost:3000
       DOLOS_API_DATABASE_USERNAME: root
       DOLOS_API_DATABASE_PASSWORD: dolos
       DOLOS_API_DATABASE_HOST: db


### PR DESCRIPTION
If Dolos is hosted publicly behind a reverse proxy, Rails does not appropriately detect that HTTPS should be used for urls generated by the API, causing the front-end to fetch the CSV files using http instead of https (see #1518).

This PR fixes this issue by introducing a new environment variable `DOLOS_API_URL` which is used to detect the hosting properties. It supersedes the environment variables `DOLOS_API_HOSTS` and `DOLOS_API_DISABLE_FORCE_SSL`.

Unfortunately there is a bug in rails where files served using ActiveStorage don't listen to the `relative_root_url` (https://github.com/rails/rails/issues/43633). This can cause issues if the API is hosted on a subdirectory (`https://example.com/api`). You can avoid this issue by using another application/proxy to set the base url (like Phusion Passenger's [`passenger_base_uri`](https://www.phusionpassenger.com/docs/references/config_reference/nginx/#passenger_base_uri)), or by adding an extra redirect location from `/rails/*` to `/rails/api/*`.

For example for NGINX, the following snippet would host Dolos on `https://dolos.localhost:9090`:

```nginx
http {
    upstream dolos-api {
        server api:3000;
    }

    server {
        listen 9090 ssl;
        server_name dolos.localhost;
        ssl_certificate /root/ssl/cert.crt;
        ssl_certificate_key /root/ssl/cert.key;


		# Serve the static front-end files
        location / {
            root /path/to/dolos-web;
        }

        location /api {
            proxy_set_header Host $host;
            proxy_set_header X-Forwarded-Host 'dolos.localhost:9090';
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_pass http://dolos-api/;
        }

		# Required due to a bug in Rails' ActiveStorage
        location /rails {
            return 302 https://dolos.localhost:9090/api$request_uri;
        }
    }
}
```

