### PR TITLE
[experimental] Add ability to ignore template code or frequently occuring fingerprints

### DIFF
--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -58,6 +58,13 @@ export function runCommand(program: Command): Command {
       x => parseFloat(x),
     )
     .option(
+      "-i, --ignore <path>",
+      Utils.indent(
+        "Path of a file with template/boilerplate code. " +
+        "Code fragments matching with this file will be ignored."
+      )
+    )
+    .option(
       "-L, --limit-results <integer>",
       Utils.indent(
         "Specifies how many matching file pairs are shown in the result. " +
@@ -171,6 +178,7 @@ interface RunOptions extends Options {
   host: string;
   outputFormat: string;
   outputDestination: string;
+  ignore: string;
 }
 
 export async function run(locations: string[], options: RunOptions): Promise<void> {
@@ -199,7 +207,7 @@ export async function run(locations: string[], options: RunOptions): Promise<voi
       sortBy: options.sortBy,
       fragmentSortBy: options.fragmentSortBy,
     });
-    const report = await dolos.analyzePaths(locations);
+    const report = await dolos.analyzePaths(locations, options.ignore);
 
     if (report.warnings.length > 0) {
       report.warnings.forEach(warn => warning(warn));

--- a/cli/src/cli/views/fileView.ts
+++ b/cli/src/cli/views/fileView.ts
@@ -12,14 +12,14 @@ import {
 function writeCSVto<T>(
   out: Writable,
   data: T[],
-  extractor: {[field: string]: (obj: T) => string | number | boolean | null}
+  extractor: {[field: string]: (obj: T) => string | number | null}
 ): void {
 
   const csv = stringify();
   csv.pipe(out);
 
   const keys: string[] = [];
-  const extractors: Array<(obj: T) => string | number | boolean | null> = [];
+  const extractors: Array<(obj: T) => string | number | null> = [];
   for (const [key, extract] of Object.entries(extractor)) {
     keys.push(key);
     extractors.push(extract);
@@ -77,7 +77,7 @@ export class FileView extends View {
       {
         "id": s => s.id,
         "hash": s => s.hash,
-        "ignored": s => s.ignored,
+        "ignored": s => s.ignored ? "true" : "false",
         "data": s => s.kgram?.join(" ") || null,
         "files": s => JSON.stringify(s.files().map(f => f.id))
       });
@@ -86,9 +86,10 @@ export class FileView extends View {
   public writeFiles(out: Writable): void {
     writeCSVto<FileEntry>(
       out,
-      this.report.entries(),
+      this.report.entries().concat(this.report.ignoredEntries()),
       {
         "id": f => f.file.id,
+        "ignored": f => f.isIgnored ? "true" : "false",
         "path": f => f.file.path,
         "content": f => f.file.content,
         "amountOfKgrams": f => f.kgrams.length,

--- a/cli/src/cli/views/fileView.ts
+++ b/cli/src/cli/views/fileView.ts
@@ -12,14 +12,14 @@ import {
 function writeCSVto<T>(
   out: Writable,
   data: T[],
-  extractor: {[field: string]: (obj: T) => string | number | null}
+  extractor: {[field: string]: (obj: T) => string | number | boolean | null}
 ): void {
 
   const csv = stringify();
   csv.pipe(out);
 
   const keys: string[] = [];
-  const extractors: Array<(obj: T) => string | number | null> = [];
+  const extractors: Array<(obj: T) => string | number | boolean | null> = [];
   for (const [key, extract] of Object.entries(extractor)) {
     keys.push(key);
     extractors.push(extract);
@@ -77,6 +77,7 @@ export class FileView extends View {
       {
         "id": s => s.id,
         "hash": s => s.hash,
+        "ignored": s => s.ignored,
         "data": s => s.kgram?.join(" ") || null,
         "files": s => JSON.stringify(s.files().map(f => f.id))
       });

--- a/core/src/algorithm/fingerprintIndex.ts
+++ b/core/src/algorithm/fingerprintIndex.ts
@@ -23,11 +23,6 @@ export interface Occurrence {
   side: ASTRegion;
 }
 
-export interface FingerprintIndexOptions {
-  maxFingerprintCount?: number;
-  maxFingerprintPercentage?: number;
-}
-
 export class FingerprintIndex {
   // HashFilter transforms tokens into (a selection of) hashes
   private readonly hashFilter: HashFilter;

--- a/core/src/algorithm/pair.ts
+++ b/core/src/algorithm/pair.ts
@@ -77,8 +77,9 @@ export class Pair extends Identifiable {
     this.rightIgnored = leftEntry.ignored.size;
     this.leftTotal = leftEntry.kgrams.length;
     this.rightTotal = rightEntry.kgrams.length;
-    if (this.leftTotal + this.rightTotal > 0) {
-      this.similarity = (this.leftCovered + this.rightCovered) / (this.leftTotal + this.rightTotal - this.leftIgnored - this.rightIgnored);
+    const denominator = this.leftTotal + this.rightTotal - this.leftIgnored - this.rightIgnored;
+    if (denominator > 0) {
+      this.similarity = (this.leftCovered + this.rightCovered) / denominator;
     } else {
       this.similarity = 0;
     }

--- a/core/src/algorithm/pair.ts
+++ b/core/src/algorithm/pair.ts
@@ -30,6 +30,8 @@ export class Pair extends Identifiable {
   public readonly rightTotal;
   public readonly longest;
   public readonly similarity;
+  public readonly leftIgnored;
+  public readonly rightIgnored;
 
   constructor(
     public readonly leftEntry: FileEntry,
@@ -71,10 +73,12 @@ export class Pair extends Identifiable {
 
     this.leftCovered = left.length;
     this.rightCovered = right.length;
+    this.leftIgnored = leftEntry.ignored.size;
+    this.rightIgnored = leftEntry.ignored.size;
     this.leftTotal = leftEntry.kgrams.length;
     this.rightTotal = rightEntry.kgrams.length;
     if (this.leftTotal + this.rightTotal > 0) {
-      this.similarity = (this.leftCovered + this.rightCovered) / (this.leftTotal + this.rightTotal);
+      this.similarity = (this.leftCovered + this.rightCovered) / (this.leftTotal + this.rightTotal - this.leftIgnored - this.rightIgnored);
     } else {
       this.similarity = 0;
     }

--- a/core/src/algorithm/sharedFingerprint.ts
+++ b/core/src/algorithm/sharedFingerprint.ts
@@ -4,6 +4,9 @@ import { Identifiable } from "../util/identifiable.js";
 
 export class SharedFingerprint extends Identifiable {
 
+  // Whether this SharedFingerprint occurs in the boilerplate/template code
+  public ignored: boolean = false;
+
   private partMap: Map<TokenizedFile, Array<Occurrence>> = new Map();
 
   constructor(

--- a/core/src/algorithm/sharedFingerprint.ts
+++ b/core/src/algorithm/sharedFingerprint.ts
@@ -43,4 +43,8 @@ export class SharedFingerprint extends Identifiable {
   public fileCount(): number {
     return this.partMap.size;
   }
+
+  public includesFile(file: TokenizedFile): boolean {
+    return this.partMap.has(file);
+  }
 }

--- a/core/src/test/pair.test.ts
+++ b/core/src/test/pair.test.ts
@@ -55,15 +55,16 @@ test("paired occurrence merging & squashing", t => {
     kgrams: new Array<Range>(),
     shared: new Set<SharedFingerprint>(),
     ignored: new Set<SharedFingerprint>(),
-
-    file: leftFile
+    file: leftFile,
+    isIgnored: false,
   };
 
   const right = {
     kgrams: new Array<Range>(),
     shared: new Set<SharedFingerprint>(),
     ignored: new Set<SharedFingerprint>(),
-    file: rightFile
+    file: rightFile,
+    isIgnored: false,
   };
 
 

--- a/core/src/test/pair.test.ts
+++ b/core/src/test/pair.test.ts
@@ -54,12 +54,15 @@ test("paired occurrence merging & squashing", t => {
   const left = {
     kgrams: new Array<Range>(),
     shared: new Set<SharedFingerprint>(),
+    ignored: new Set<SharedFingerprint>(),
+
     file: leftFile
   };
 
   const right = {
     kgrams: new Array<Range>(),
     shared: new Set<SharedFingerprint>(),
+    ignored: new Set<SharedFingerprint>(),
     file: rightFile
   };
 

--- a/docs/docs/running.md
+++ b/docs/docs/running.md
@@ -49,6 +49,28 @@ You can show all command line options by passing the `-h` or `--help` flag or by
 You can improve the plagiarism detection report by adding metadata to your submissions (submission time, labels, author name, ...).
 See the page about [adding metadata](/docs/adding-metadata) to see how.
 
+## Ignoring template code
+
+Programming exercises often have code in common that is not plagiarised. For example: class and method definitions, given test cases, boilerplate code, ...
+Dolos will often detect these code fragments as similar and include them in the similarity score, making it harder to spot actual plagiarism.
+
+With the `-i <path>` or `--ignore <path>` parameter, you can add an _ignore_ file (often also called a _template_ or _boilerplate_) to the analysis.
+Code fragments from analysed solutions that match with this file will be ignored and these fingerprints will not count towards similarity.
+
+In addition, it is also possible to **automaticaly detect** common code.
+By passing `-m <integer>` or `--max-fingerprint-count <integer>` you can specify a maximum number of files a code fragment can occur in before it is ignored.
+With `-M <fraction>` or `--max-fingerprint-percentage <fraction>` it is possible to specify this number as a fraction (percentage) of the total analysed file count.
+It is possible to combine this with specifying an ignore file with the `-i` option.
+
+
+Example usage:
+
+```sh
+# Ignore all code fragments occurring in more than half of the files,
+# or occurring in template.js
+dolos run -M 0.5 -i template.js solutions/*.js 
+```
+
 ## Modifying plagiarism detection parameters
 
 The plagiarism detection parameters can be altered by passing the relevant arguments when running Dolos.

--- a/docs/docs/running.md
+++ b/docs/docs/running.md
@@ -57,7 +57,7 @@ Dolos will often detect these code fragments as similar and include them in the 
 With the `-i <path>` or `--ignore <path>` parameter, you can add an _ignore_ file (often also called a _template_ or _boilerplate_) to the analysis.
 Code fragments from analysed solutions that match with this file will be ignored and these fingerprints will not count towards similarity.
 
-In addition, it is also possible to **automaticaly detect** common code.
+In addition, it is also possible to **automatically detect** common code.
 By passing `-m <integer>` or `--max-fingerprint-count <integer>` you can specify a maximum number of files a code fragment can occur in before it is ignored.
 With `-M <fraction>` or `--max-fingerprint-percentage <fraction>` it is possible to specify this number as a fraction (percentage) of the total analysed file count.
 It is possible to combine this with specifying an ignore file with the `-i` option.

--- a/lib/src/lib/dolos.ts
+++ b/lib/src/lib/dolos.ts
@@ -125,6 +125,7 @@ export class Dolos {
     nameCandidate?: string,
     template?: File
   ): Promise<Report> {
+
     if (this.index == null) {
       if (this.options.language) {
         this.language = await this.languagePicker.findLanguage(this.options.language);
@@ -135,7 +136,6 @@ export class Dolos {
       this.tokenizer = await this.language.createTokenizer();
       this.index = new FingerprintIndex(this.options.kgramLength, this.options.kgramsInWindow, this.options.kgramData);
     }
-
     const warnings = [];
     let filteredFiles;
     if (this.languageDetected) {
@@ -152,21 +152,31 @@ export class Dolos {
       filteredFiles = files;
     }
 
-    if (files.length < 2) {
+    if (filteredFiles.length < 2) {
       throw new Error("You need to supply at least two files");
-    } else if (files.length == 2 && this.options.maxFingerprintPercentage !== null) {
+    } else if (filteredFiles.length == 2 && this.options.maxFingerprintPercentage !== null) {
       throw new Error("You have given a maximum hash percentage but your are " +
         "comparing two files. Each matching hash will thus " +
         "be present in 100% of the files. This option does only" +
         "make sense when comparing more than two files.");
     }
 
+    let maxFingerprintFileCount = undefined;
+    if (this.options.maxFingerprintCount != null) {
+      maxFingerprintFileCount  = this.options.maxFingerprintCount;
+    } else if (this.options.maxFingerprintPercentage != null) {
+      const total = this.index.entries().length + filteredFiles.length;
+      maxFingerprintFileCount = this.options.maxFingerprintPercentage * total;
+    }
+
+    this.index.updateMaxFingerprintFileCount(maxFingerprintFileCount);
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const tokenizedFiles = filteredFiles.map(f => this.tokenizer!.tokenizeFile(f));
     this.index.addFiles(tokenizedFiles);
     if (template) {
       const tokenizedTemplate = this.tokenizer!.tokenizeFile(template);
-      this.index.addTemplate(tokenizedTemplate);
+      this.index.addIgnoredFile(tokenizedTemplate);
     }
 
     return new Report(

--- a/lib/src/lib/dolos.ts
+++ b/lib/src/lib/dolos.ts
@@ -91,7 +91,7 @@ export class Dolos {
   }
 
 
-  public async analyzePaths(paths: string[]): Promise<Report> {
+  public async analyzePaths(paths: string[], template?: string): Promise<Report> {
     let files = null;
     let nameCandidate = undefined;
     if(paths.length == 1) {
@@ -113,14 +113,19 @@ export class Dolos {
         nameCandidate = path.basename(paths[0]) + " & " + path.basename(paths[1]);
       }
     }
-    return this.analyze((await files).ok(), nameCandidate);
+    let templateFile;
+    if (template) {
+      templateFile = (await readPath(template)).ok();
+    }
+    return this.analyze((await files).ok(), nameCandidate, templateFile);
   }
 
   public async analyze(
     files: Array<File>,
-    nameCandidate?: string
+    nameCandidate?: string,
+    template?: File
   ): Promise<Report> {
-
+    console.log(template);
     if (this.index == null) {
       if (this.options.language) {
         this.language = await this.languagePicker.findLanguage(this.options.language);

--- a/lib/src/lib/dolos.ts
+++ b/lib/src/lib/dolos.ts
@@ -91,7 +91,7 @@ export class Dolos {
   }
 
 
-  public async analyzePaths(paths: string[], template?: string): Promise<Report> {
+  public async analyzePaths(paths: string[], ignore?: string): Promise<Report> {
     let files = null;
     let nameCandidate = undefined;
     if(paths.length == 1) {
@@ -113,17 +113,17 @@ export class Dolos {
         nameCandidate = path.basename(paths[0]) + " & " + path.basename(paths[1]);
       }
     }
-    let templateFile;
-    if (template) {
-      templateFile = (await readPath(template)).ok();
+    let ignoredFile;
+    if (ignore) {
+      ignoredFile = (await readPath(ignore)).ok();
     }
-    return this.analyze((await files).ok(), nameCandidate, templateFile);
+    return this.analyze((await files).ok(), nameCandidate, ignoredFile);
   }
 
   public async analyze(
     files: Array<File>,
     nameCandidate?: string,
-    template?: File
+    ignoredFile?: File
   ): Promise<Report> {
 
     if (this.index == null) {
@@ -174,8 +174,8 @@ export class Dolos {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const tokenizedFiles = filteredFiles.map(f => this.tokenizer!.tokenizeFile(f));
     this.index.addFiles(tokenizedFiles);
-    if (template) {
-      const tokenizedTemplate = this.tokenizer!.tokenizeFile(template);
+    if (ignoredFile) {
+      const tokenizedTemplate = this.tokenizer!.tokenizeFile(ignoredFile);
       this.index.addIgnoredFile(tokenizedTemplate);
     }
 

--- a/lib/src/lib/dolos.ts
+++ b/lib/src/lib/dolos.ts
@@ -125,7 +125,6 @@ export class Dolos {
     nameCandidate?: string,
     template?: File
   ): Promise<Report> {
-    console.log(template);
     if (this.index == null) {
       if (this.options.language) {
         this.language = await this.languagePicker.findLanguage(this.options.language);
@@ -165,6 +164,10 @@ export class Dolos {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const tokenizedFiles = filteredFiles.map(f => this.tokenizer!.tokenizeFile(f));
     this.index.addFiles(tokenizedFiles);
+    if (template) {
+      const tokenizedTemplate = this.tokenizer!.tokenizeFile(template);
+      this.index.addTemplate(tokenizedTemplate);
+    }
 
     return new Report(
       this.options,

--- a/lib/src/lib/report.ts
+++ b/lib/src/lib/report.ts
@@ -9,11 +9,8 @@ export interface Metadata extends DolosOptions {
 }
 
 export class Report {
-  // maximum amount of files a kgram can occur in a file before it is ignored
-  private readonly kgramMaxFileOccurrences: number;
 
   private pairs: Array<Pair> = [];
-  private fingerprints: Array<SharedFingerprint> = [];
 
   public readonly name: string;
   public readonly createdAt: string = new Date().toISOString();
@@ -26,23 +23,11 @@ export class Report {
     name?: string,
     public readonly warnings: string[] = [],
   ) {
-    if (this.options.maxFingerprintCount != null) {
-      this.kgramMaxFileOccurrences = this.options.maxFingerprintCount;
-    } else if (this.options.maxFingerprintPercentage != null) {
-      this.kgramMaxFileOccurrences = this.options.maxFingerprintPercentage * this.files.length;
-    } else {
-      this.kgramMaxFileOccurrences = this.files.length;
-    }
-
     if (this.options.reportName) {
       this.name = this.options.reportName;
     } else {
       this.name = name || `${this.files.length} ${ this.language?.name } files`;
     }
-
-    this.fingerprints = Array.from(index.sharedFingerprints()).filter(
-      (k: SharedFingerprint) => k.fileCount() <= this.kgramMaxFileOccurrences,
-    );
   }
 
   public getPair(file1: TokenizedFile, file2: TokenizedFile): Pair {
@@ -57,7 +42,7 @@ export class Report {
   }
 
   public sharedFingerprints(): Array<SharedFingerprint> {
-    return Array.from(this.fingerprints.values());
+    return this.index.sharedFingerprints();
   }
 
   public entries(): Array<FileEntry> {

--- a/lib/src/lib/report.ts
+++ b/lib/src/lib/report.ts
@@ -49,6 +49,10 @@ export class Report {
     return this.index.entries();
   }
 
+  public ignoredEntries(): Array<FileEntry> {
+    return this.index.ignoredEntries();
+  }
+
   public metadata(): Metadata {
     return {
       ...this.options.asObject(),

--- a/lib/src/test/dolos.test.ts
+++ b/lib/src/test/dolos.test.ts
@@ -288,6 +288,33 @@ test("should generate warning when not all files match detected language", async
   t.is(1, pairs.length);
 });
 
+test("should ignore template code", async t => {
+  const dolos = new Dolos();
+
+  const report = await dolos.analyzePaths([
+    "./src/test/fixtures/javascript/boilerplate_copy.js",
+    "./src/test/fixtures/javascript/implementation-unique.js",
+    "./src/test/fixtures/javascript/implementation-alternative.js",
+    "./src/test/fixtures/javascript/implementation-alternative-similar.js",
+  ],     "./src/test/fixtures/javascript/boilerplate_copy.js");
+
+  const files = report.files;
+  t.is(4, files.length);
+
+  const boilerplate = files[0];
+  const unique = files[1];
+  const alternative = files[2];
+  const similar  = files[3];
+
+  console.debug(report.allPairs());
+
+  // Boilerplate copy should not have a match
+  t.is(0, report.getPair(boilerplate, unique).similarity);
+  t.is(0, report.getPair(boilerplate, alternative).similarity);
+  t.is(0, report.getPair(boilerplate, similar).similarity);
+  t.fail();
+});
+
 test.failing("repeating sequences should not cause too many fragments", async t => {
   const dolos = new Dolos();
 

--- a/lib/src/test/dolos.test.ts
+++ b/lib/src/test/dolos.test.ts
@@ -306,13 +306,86 @@ test("should ignore template code", async t => {
   const alternative = files[2];
   const similar  = files[3];
 
-  console.debug(report.allPairs());
+  // Boilerplate copy should not have a match
+  t.is(0, report.getPair(boilerplate, unique).similarity);
+  t.is(0, report.getPair(boilerplate, alternative).similarity);
+  t.is(0, report.getPair(boilerplate, similar).similarity);
+
+
+  const unique_alternative = report.getPair(unique, alternative);
+  const unique_similar = report.getPair(unique, similar);
+  const alternative_similar = report.getPair(alternative, similar);
+  t.true(unique_alternative.similarity < alternative_similar.similarity, "Pairs with unique should be less similar");
+  t.true(unique_similar.similarity < alternative_similar.similarity, "Pairs with unique should be less similar");
+  t.true(alternative_similar.similarity > 0.5, "Pairs with similar code should have a similarity above 50%");
+});
+
+test("should ignore with maxFingerprintCount", async t => {
+  const dolos = new Dolos({
+    maxFingerprintCount: 3
+  });
+
+  const report = await dolos.analyzePaths([
+    "./src/test/fixtures/javascript/boilerplate_copy.js",
+    "./src/test/fixtures/javascript/implementation-unique.js",
+    "./src/test/fixtures/javascript/implementation-alternative.js",
+    "./src/test/fixtures/javascript/implementation-alternative-similar.js",
+  ]);
+
+  const files = report.files;
+  t.is(4, files.length);
+
+  const boilerplate = files[0];
+  const unique = files[1];
+  const alternative = files[2];
+  const similar  = files[3];
 
   // Boilerplate copy should not have a match
   t.is(0, report.getPair(boilerplate, unique).similarity);
   t.is(0, report.getPair(boilerplate, alternative).similarity);
   t.is(0, report.getPair(boilerplate, similar).similarity);
-  t.fail();
+
+
+  const unique_alternative = report.getPair(unique, alternative);
+  const unique_similar = report.getPair(unique, similar);
+  const alternative_similar = report.getPair(alternative, similar);
+  t.true(unique_alternative.similarity < alternative_similar.similarity, "Pairs with unique should be less similar");
+  t.true(unique_similar.similarity < alternative_similar.similarity, "Pairs with unique should be less similar");
+  t.true(alternative_similar.similarity > 0.5, "Pairs with similar code should have a similarity above 50%");
+});
+
+test("should ignore with maxFingerprintPercentage", async t => {
+  const dolos = new Dolos({
+    maxFingerprintPercentage: 0.75
+  });
+
+  const report = await dolos.analyzePaths([
+    "./src/test/fixtures/javascript/boilerplate_copy.js",
+    "./src/test/fixtures/javascript/implementation-unique.js",
+    "./src/test/fixtures/javascript/implementation-alternative.js",
+    "./src/test/fixtures/javascript/implementation-alternative-similar.js",
+  ]);
+
+  const files = report.files;
+  t.is(4, files.length);
+
+  const boilerplate = files[0];
+  const unique = files[1];
+  const alternative = files[2];
+  const similar  = files[3];
+
+  // Boilerplate copy should not have a match
+  t.is(0, report.getPair(boilerplate, unique).similarity);
+  t.is(0, report.getPair(boilerplate, alternative).similarity);
+  t.is(0, report.getPair(boilerplate, similar).similarity);
+
+
+  const unique_alternative = report.getPair(unique, alternative);
+  const unique_similar = report.getPair(unique, similar);
+  const alternative_similar = report.getPair(alternative, similar);
+  t.true(unique_alternative.similarity < alternative_similar.similarity, "Pairs with unique should be less similar");
+  t.true(unique_similar.similarity < alternative_similar.similarity, "Pairs with unique should be less similar");
+  t.true(alternative_similar.similarity > 0.5, "Pairs with similar code should have a similarity above 50%");
 });
 
 test.failing("repeating sequences should not cause too many fragments", async t => {

--- a/lib/src/test/fixtures/javascript/boilerplate.js
+++ b/lib/src/test/fixtures/javascript/boilerplate.js
@@ -1,0 +1,18 @@
+class Pearson {
+    constructor(tabel, combineer) {
+        this.tabel = tabel || [...new Array(256).keys()];
+        if (this.tabel.length !== 256) {
+            throw "AssertionError: ongeldige tabel";
+        }
+        for (let i = 0; i < 256; i++) {
+            if (!this.tabel.includes(i)) {
+                throw "AssertionError: ongeldige tabel";
+            }
+        }
+        this.combineer = combineer || ((h, v) => (h + v) % 256);
+    }
+
+    hash(s) {
+        // TODO: IMPLEMENT THIS FUNCTION
+    }
+}

--- a/lib/src/test/fixtures/javascript/boilerplate_copy.js
+++ b/lib/src/test/fixtures/javascript/boilerplate_copy.js
@@ -1,0 +1,18 @@
+class Pearson {
+    constructor(tabel, combineer) {
+        this.tabel = tabel || [...new Array(256).keys()];
+        if (this.tabel.length !== 256) {
+            throw "AssertionError: ongeldige tabel";
+        }
+        for (let i = 0; i < 256; i++) {
+            if (!this.tabel.includes(i)) {
+                throw "AssertionError: ongeldige tabel";
+            }
+        }
+        this.combineer = combineer || ((h, v) => (h + v) % 256);
+    }
+
+    hash(s) {
+        // TODO: IMPLEMENT THIS FUNCTION
+    }
+}

--- a/lib/src/test/fixtures/javascript/implementation-alternative-similar.js
+++ b/lib/src/test/fixtures/javascript/implementation-alternative-similar.js
@@ -1,0 +1,30 @@
+class Pearson {
+    constructor(tabel, combineer) {
+        this.tabel = tabel || [...new Array(256).keys()];
+        if (this.tabel.length !== 256) {
+            throw "AssertionError: ongeldige tabel";
+        }
+        for (let i = 0; i < 256; i++) {
+            if (!this.tabel.includes(i)) {
+                throw "AssertionError: ongeldige tabel";
+            }
+        }
+        this.combineer = combineer || ((h, v) => (h + v) % 256);
+    }
+
+    hash(s) {
+        // TODO: implement this function
+        let r = 256;
+        for (let i = 0; i < 256; i++) {
+            r -=1;
+        }
+        let a = r, b = 0;
+        while(b < s.length) {
+            const c = s[b].charCodeAt(0);
+            const x = this.combineer(c, a);
+            a = this.tabel[x];
+            b += 1;
+        }
+        return a;
+    }
+}

--- a/lib/src/test/fixtures/javascript/implementation-alternative.js
+++ b/lib/src/test/fixtures/javascript/implementation-alternative.js
@@ -1,0 +1,25 @@
+class Pearson {
+    constructor(tabel, combineer) {
+        this.tabel = tabel || [...new Array(256).keys()];
+        if (this.tabel.length !== 256) {
+            throw "AssertionError: ongeldige tabel";
+        }
+        for (let i = 0; i < 256; i++) {
+            if (!this.tabel.includes(i)) {
+                throw "AssertionError: ongeldige tabel";
+            }
+        }
+        this.combineer = combineer || ((h, v) => (h + v) % 256);
+    }
+
+    hash(s) {
+        let h = 0, i = 0;
+        while(i < s.length) {
+            const c = s[i].charCodeAt(0);
+            const x = this.combineer(c, h);
+            h = this.tabel[x];
+            i += 1;
+        }
+        return h;
+    }
+}

--- a/lib/src/test/fixtures/javascript/implementation-unique.js
+++ b/lib/src/test/fixtures/javascript/implementation-unique.js
@@ -1,0 +1,22 @@
+class Pearson {
+    constructor(tabel, combineer) {
+        this.tabel = tabel || [...new Array(256).keys()];
+        if (this.tabel.length !== 256) {
+            throw "AssertionError: ongeldige tabel";
+        }
+        for (let i = 0; i < 256; i++) {
+            if (!this.tabel.includes(i)) {
+                throw "AssertionError: ongeldige tabel";
+            }
+        }
+        this.combineer = combineer || ((h, v) => (h + v) % 256);
+    }
+
+    hash(s) {
+        let h = 0;
+        for (let c of s) {
+            h = this.tabel[this.combineer(h, c.charCodeAt(0))];
+        }
+        return h;
+    }
+}

--- a/web/src/api/models/file.ts
+++ b/web/src/api/models/file.ts
@@ -9,6 +9,7 @@ export interface FileIndeterminate {
   ast: string[] | string;
   mapping: Selection[] | string;
   amountOfKgrams: number;
+  ignored: boolean;
   label: Label;
   extra: {
     timestamp?: Date;

--- a/web/src/api/models/kgram.ts
+++ b/web/src/api/models/kgram.ts
@@ -2,6 +2,7 @@ import { Hash, File } from "@/api/models";
 
 export interface Kgram {
   id: number;
+  ignored: boolean;
   hash: Hash;
   data: string;
   files: File[];

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -156,6 +156,7 @@ export const useFileStore = defineStore("file", () => {
       const extra = JSON.parse(row.extra || "{}");
       extra.timestamp = extra.createdAt && new Date(extra.createdAt);
       hasTimestamps = hasTimestamps || !!extra.timestamp;
+      file.ignored = row.ignored == "true"
       file.extra = extra;
       file.ast = JSON.parse(row.ast);
       file.mapping = JSON.parse(row.mapping);
@@ -203,7 +204,9 @@ export const useFileStore = defineStore("file", () => {
         labels: extra.labels,
       };
 
-      files[file.id] = file;
+      if (!file.ignored) {
+        files[file.id] = file;
+      }
     }
 
     // Find the common path in the files.

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -299,6 +299,7 @@ export const useFileStore = defineStore("file", () => {
   );
 
   return {
+    ignoredFile,
     filesById,
     filesList,
     filesActiveById,

--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -21,6 +21,7 @@ export const useFileStore = defineStore("file", () => {
   // State
   const hydrated = shallowRef(false);
 
+  const ignoredFile = shallowRef<File | undefined>();
   const filesById = shallowRef<File[]>([]);
   const filesList = computed(() => Object.values(filesById.value));
 
@@ -107,6 +108,7 @@ export const useFileStore = defineStore("file", () => {
     const parsed = parse(await fetch());
     filesById.value = parsed.files;
     filesActiveById.value = parsed.files;
+    ignoredFile.value = parsed.ignoredFile;
     legend.value = parsed.labels;
     hasLabels.value = parsed.hasLabels;
     hasUnlabeled.value = parsed.hasUnlabeled;
@@ -122,6 +124,7 @@ export const useFileStore = defineStore("file", () => {
 
   // Parse the files from a CSV string.
   function parse(fileData: any[]): {
+    ignoredFile?: File;
     files: File[];
     labels: Legend;
     hasLabels: boolean;
@@ -145,6 +148,7 @@ export const useFileStore = defineStore("file", () => {
 
     const files: File[] = [];
     const labels: Legend = {};
+    let ignoredFile;
     let hasLabels = false;
     let hasUnlabeled = false;
     let hasTimestamps = false;
@@ -206,6 +210,8 @@ export const useFileStore = defineStore("file", () => {
 
       if (!file.ignored) {
         files[file.id] = file;
+      } else {
+        ignoredFile = file;
       }
     }
 
@@ -233,7 +239,7 @@ export const useFileStore = defineStore("file", () => {
       labels[defaultLabel.name] = defaultLabel;
     }
 
-    return { files, labels, hasLabels, hasUnlabeled, hasTimestamps };
+    return { files, ignoredFile, labels, hasLabels, hasUnlabeled, hasTimestamps };
   }
 
   // Anonymize the data.

--- a/web/src/api/stores/kgram.store.ts
+++ b/web/src/api/stores/kgram.store.ts
@@ -27,6 +27,7 @@ export const useKgramStore = defineStore("kgrams", () => {
       kgrams[id] = {
         id,
         hash: parseInt(row.hash),
+        ignored: row.ignored == "true",
         data: row.data,
         files,
       };

--- a/web/src/api/stores/kgram.store.ts
+++ b/web/src/api/stores/kgram.store.ts
@@ -76,6 +76,7 @@ export const useKgramStore = defineStore("kgrams", () => {
 
   return {
     kgrams,
+    ignoredKgrams,
     hydrated,
     hydrate,
   };

--- a/web/src/api/stores/pair.store.ts
+++ b/web/src/api/stores/pair.store.ts
@@ -113,9 +113,11 @@ export const usePairStore = defineStore("pairs", () => {
   // Populate the fragments for a given pair.
   async function populateFragments(pair: Pair): Promise<Pair> {
     const customOptions = metadataStore.metadata;
-    const kmers = kgramStore.kgrams;
+    const kgrams = kgramStore.kgrams;
+    const ignoredKgrams = kgramStore.ignoredKgrams;
+    const ignoredFile = fileStore.ignoredFile;
 
-    const pairWithFragments = await dataWorker.populateFragments(pair, customOptions, kmers);
+    const pairWithFragments = await dataWorker.populateFragments(pair, customOptions, kgrams, ignoredKgrams, ignoredFile);
     pairsById.value[pair.id] = pairWithFragments;
     return pairWithFragments;
   }

--- a/web/src/api/workers/data.worker.ts
+++ b/web/src/api/workers/data.worker.ts
@@ -49,6 +49,7 @@ export function populateFragments(
   const leftFile = fileToTokenizedFile(pair.leftFile);
   const rightFile = fileToTokenizedFile(pair.rightFile);
   index.addFiles([leftFile, rightFile]);
+  index.addIgnoredHashes(kgrams.filter(k => k.ignored).map(k => k.hash));
   const reportPair = index.getPair(leftFile, rightFile);
 
   const kmersMap: Map<Hash, Kgram> = new Map();

--- a/web/src/api/workers/data.worker.ts
+++ b/web/src/api/workers/data.worker.ts
@@ -1,5 +1,6 @@
 import { fileToTokenizedFile } from "@/api/utils";
 import {
+  File,
   Pair,
   Kgram,
   Metadata,
@@ -40,7 +41,9 @@ export function parseFragments(
 export function populateFragments(
   pair: Pair,
   metadata: Metadata,
-  kgrams: Kgram[]
+  kgrams: Kgram[],
+  ignoredKgrams: Kgram[],
+  ignoredFile?: File,
 ): Pair {
   const customOptions = metadata;
   const kmers = kgrams;
@@ -49,7 +52,11 @@ export function populateFragments(
   const leftFile = fileToTokenizedFile(pair.leftFile);
   const rightFile = fileToTokenizedFile(pair.rightFile);
   index.addFiles([leftFile, rightFile]);
-  index.addIgnoredHashes(kgrams.filter(k => k.ignored).map(k => k.hash));
+  if (ignoredFile) {
+    const ignored = fileToTokenizedFile(ignoredFile);
+    index.addIgnoredFile(ignored);
+  }
+  index.addIgnoredHashes(ignoredKgrams.map(k => k.hash));
   const reportPair = index.getPair(leftFile, rightFile);
 
   const kmersMap: Map<Hash, Kgram> = new Map();

--- a/web/src/composables/useMonacoEditorWorkers.ts
+++ b/web/src/composables/useMonacoEditorWorkers.ts
@@ -4,10 +4,7 @@ import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 
 export function useMonacoEditorWorkers() {
   onMounted(() => {
-    self.MonacoEnvironment = {
-      getWorker() {
-        return new EditorWorker()
-      }
-    }
+    self.MonacoEnvironment ||= {};
+    self.MonacoEnvironment.getWorker = () => new EditorWorker();
   });
 }


### PR DESCRIPTION
This PR adds the ability to ignore template code by manually specifying ignore files or by setting a maximum count or percentage of files a code fragment can occur in before it is ignored.

**Note:** this feature is currently **experimental**. We're not convinced of the initial results and will be performing more tests to see whether this functionality would actually improve plagiarism reports or not.

This option is currently not available in the web server, however we are thinking how to implement this (see #1535).

Meanwhile the following changes have been done to the `dolos`, `dolos-core`, and `dolos-lib` npm packages: 

# API changes

## CLI

- Added a new option `-i, --ignore <path>` to ignore matches with that file in the analysis
- Fixed the options `-m, --max-fingerprint-count <integer>` and `-M, --max-fingerprint-percentage <fraction>` to ignore matches if the code is present in more than that count/percentage of files

## Core

- `FingerprintIndex` now has the ability to ignore files or fingerprints occurring in more than a specified amount of files. 
	- `constructor`: added optional argument `maxFingerprintFileCount` which can be used to set the maximum number of files a fingerprint can occur in before it is ignored.
	- new function `addIgnoredFile(file: TokenizedFile): void` can be used to ignore all the fingerprints in a file.
	- new function `ignoredEntries(): Array<FileEntry>` to retrieve all ignored files.
	- new functions `getMaxFingerprintFileCount(): number` and `updateMaxFingerprintFileCount(maxFingerprintFileCount: number | undefined)` to retrieve and update the `maxFingerprintFileCount`. The change will immediately change the index to reflect this value.
	- new function `addIgnoredHashes(hashes: Array<Hash>)` which can be used to manually ignore certain hashes.
- interface `FileEntry`: added field `ignored: Set<SharedFingerprints>` to track ignored fingerprints and field `isIgnored: boolean` to sign whether this file is an ignored file or not.
- `SharedFingerprint` now has a boolean `ignored` to reflect whether this shared fingerprint is ignored or not.
  - new function `includesFile(file: TokenizedFile): boolean` to request whether this fingerprint ins included in the given file.

## Lib

- `Dolos` class now has the option to ignore a file or ignore fingeprints occuring in more than a specified amount or percentage of files
  - The options `maxFingerprintCount` and `maxFingerprintPercentage` now have an effect (they were previously ignored): code matchign with more than this count or percentage of files will be ignored
  - `analyzePaths` has an extra optional parameter `ignore?: string` which can be set to the path of the file to ignore
  - `analyze` has an extra optional parameter `ignoredFile?: File` which can be set to the `File` to ignore
- `Report` class now has an extra function `ignoredEntries(): Array<FileEntry>` to retrieve the files that have been ignored 
 	
# Experimental results

To observe the effects of ignoring template code, we've run Dolos on a recent case of plagiarism.

The cases with confirmed plagiarism are present in the baseline comparison with a high similarity 79% and are present in one of the four clusters.

Throughout all the configurations, these cases are present the identified clusters. However the similarities decrease with the aggressiveness of the `-M` option and the other clusters vary a little.

Even with `-M .25` the confirmed cases are on top of the highest ranking submissions and comparing them does not differ much.

## Baseline (no ignoring)

![image](https://github.com/dodona-edu/dolos/assets/3226995/99f5bfb8-f78c-4638-8ea5-d3185829bd61)

## Ignore template code (`-i boilerplate.java`)

![image](https://github.com/dodona-edu/dolos/assets/3226995/72000b18-5c8b-4464-9a8b-c761e82f1f03)

## Ignore fingerprints occurring in 75% of files (`-M .75`)

![image](https://github.com/dodona-edu/dolos/assets/3226995/0f4efc39-96da-4425-96dc-4eec833e4dc8)

## Ignore fingerprints occurring in 50% of files (`-M .50`)

![image](https://github.com/dodona-edu/dolos/assets/3226995/8f2ad549-cefb-47e8-b58f-8c42148f7731)

## Ignore fingerprints occurring in 25% of files (`-M .25`)

![image](https://github.com/dodona-edu/dolos/assets/3226995/bf2ac968-ffd7-4e4e-bb4f-dc27d4af0fd4)

## Ignore template code AND fingerprints in 75% of files (`-i boilerplate.java -M .75`)

![image](https://github.com/dodona-edu/dolos/assets/3226995/8e6a3917-ed42-47da-9c62-befac838bb7e)

