### PR TITLE
Remove obsolete prepare from parsers, clarify submodule cloning

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -322,7 +322,6 @@ jobs:
       - name: Build 🔧
         run: |
           cd parsers/
-          npm run prepare
           npm run build
 
   lib-lint:
@@ -575,7 +574,6 @@ jobs:
       - name: Build parsers 🔧
         run: |
           cd parsers/
-          npm run prepare
           npm run build
 
       - name: Build lib 🔧

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -56,3 +56,39 @@ jobs:
 
       - name: Run test script
         run: ./test_package.sh
+
+  docker-api:
+    name: "Build dolos-api docker container"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Build API container
+        run: |
+          cd api
+          docker build .
+
+  docker-web:
+    name: "Build dolos-web docker container"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Build WEB container
+        run: |
+          cd web
+          docker build .
+
+  docker-cli:
+    name: "Build dolos-cli docker container"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Build WEB container
+        run: |
+          cd web
+          docker build .

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Visit our web page at <https://dolos.ugent.be/docs>.
 
 ### Building and developing
 
+To develop the parsers, library or CLI components, you will need to clone this repository recursively to include its submodules (the tree-sitter parsers):
+
+```sh
+git clone --recursive git://github.com/dodona-edu/dolos.git
+
+# or, if you have cloned the repository already:
+git submodule update --init --recursive
+```
+
 You only need to run install the dependencies once in the repository root by
 running `npm install`. This will install all dependencies and link them in each
 project's `node_modules`. You should **not** run `npm install` in each project's directory separately.

--- a/parsers/README.md
+++ b/parsers/README.md
@@ -20,15 +20,23 @@ npm install @dodona/dolos-parsers
 These parsers use [tree-sitter](https://www.npmjs.com/package/tree-sitter) to parse source code files.
 Tree-sitter currently only runs in node and will thus not run in browser environments.
 
+
+
 ## Development
 
-1. Install dependencies (preferably in the repository root)
+1. Clone the Dolos repository including the submodules
+    ```sh
+    git clone --recursive git://github.com/dodona-edu/dolos.git
+
+    # or, if you have cloned the repository already:
+    git submodule update --init --recursive
     ```
+
+
+2. Install dependencies (preferably in the repository root)
+    ```sh
     npm install
     ```
-2. Prepare the project (generate some parsers)
-    ```
-    npm run prepare
     ```
 3. Build the node bindings
     ```

--- a/parsers/package.json
+++ b/parsers/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "prepare": "(cd sql && tree-sitter generate)",
     "build": "node-gyp rebuild"
   },
   "dependencies": {

--- a/test_package.sh
+++ b/test_package.sh
@@ -13,7 +13,7 @@ npm install
 
 for dir in core parsers lib web cli; do
   echo "=== Building and packing $dir ===="
-  (cd $dir && (npm run prepare || true) && npm run build && npm pack)
+  (cd $dir && npm run build && npm pack)
 done
 
 echo "=== Building and packing complete ===="


### PR DESCRIPTION
- Remove obsolete `prepare` step from parsers.
- Clarify that the repository should be cloned recursively
- Test building Docker containers (web, api and CLI) in validation workflow

Related to #1571 