### PR TITLE
Fix purged reports loading indefinitely

### DIFF
--- a/api/app/serializers/dataset_serializer.rb
+++ b/api/app/serializers/dataset_serializer.rb
@@ -13,7 +13,8 @@ class DatasetSerializer < ApplicationSerializer
   attributes :programming_language, :zipfile, :name
 
   def zipfile
-    return unless object.zipfile.present?
+    return if object.zipfile.blank?
+
     url_for(object.zipfile)
   end
 end

--- a/api/app/serializers/dataset_serializer.rb
+++ b/api/app/serializers/dataset_serializer.rb
@@ -13,6 +13,7 @@ class DatasetSerializer < ApplicationSerializer
   attributes :programming_language, :zipfile, :name
 
   def zipfile
+    return unless object.zipfile.present?
     url_for(object.zipfile)
   end
 end

--- a/api/test/controllers/reports_controller_test.rb
+++ b/api/test/controllers/reports_controller_test.rb
@@ -74,4 +74,15 @@ class ReportsControllerTest < ActionDispatch::IntegrationTest
       assert_response :not_found
     end
   end
+
+  test 'should successfully show purged reports' do
+    delete report_url(@report), as: :json
+    assert_response :no_content
+
+    @report.reload
+    assert_equal @report.status, 'purged'
+
+    get report_url(@report), as: :json
+    assert_response :success
+  end
 end

--- a/web/src/components/upload/UploadStatus.vue
+++ b/web/src/components/upload/UploadStatus.vue
@@ -23,8 +23,11 @@ const props = defineProps<Props>();
   <v-chip v-else-if="props.status === 'error'" color="error" size="small">
     Error
   </v-chip>
-  <v-chip v-else-if="props.status === 'deleted'" color="grey" size="small">
+  <v-chip v-else-if="props.status === 'purged'" color="grey" size="small">
     Deleted
+  </v-chip>
+  <v-chip v-else-if="props.status === 'api_error'" color="error" size="small">
+    <abbr>API</abbr>&nbsp;Error
   </v-chip>
   <v-chip v-else color="grey" size="small"> Unknown </v-chip>
 </template>

--- a/web/src/components/upload/UploadsTableDeleteDialog.vue
+++ b/web/src/components/upload/UploadsTableDeleteDialog.vue
@@ -32,7 +32,7 @@ const confirm = async (): Promise<void> => {
   try {
     // Attempt to delete the upload.
     // Only delete the upload if a report id is present and the report is not already deleted.
-    if (props.report.id && props.report.status !== "deleted") {
+    if (props.report.id && props.report.status !== "purged") {
       await axios.delete(reports.getReportUrlById(props.report.id));
     }
 
@@ -72,7 +72,7 @@ const confirm = async (): Promise<void> => {
         <v-btn variant="text" icon="mdi-close" @click="open = false" />
       </v-card-title>
 
-      <v-card-text v-if="props.report.status == 'deleted'">
+      <v-card-text v-if="props.report.status == 'purged'">
           <div>Are you sure you want to delete "{{ props.report.name }}" from the list?</div>
 
           <div>

--- a/web/src/components/upload/UploadsTableInfoDialog.vue
+++ b/web/src/components/upload/UploadsTableInfoDialog.vue
@@ -31,7 +31,7 @@ const isDone = computed(
     props.report.status === "finished" ||
     props.report.status === "error" ||
     props.report.status === "failed" ||
-    props.report.status === "deleted"
+    props.report.status === "purged"
 );
 </script>
 
@@ -117,7 +117,7 @@ const isDone = computed(
       </template>
 
       <!-- Status: Deleted -->
-      <template v-else-if="props.report.status === 'deleted'">
+      <template v-else-if="props.report.status === 'purged'">
         <v-card-text>
           <v-alert type="warning" variant="tonal" class="mt-2 mb-0">
             This report has been deleted on the server and is no longer available.<br />

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -4,11 +4,14 @@ import { createApp } from "vue";
 import { createVuetify } from "vuetify";
 import { createPinia } from "pinia";
 import webFontLoader from "webfontloader";
+import axios from "axios";
 
 // Styles
 import "@mdi/font/css/materialdesignicons.css";
 import "vuetify/styles";
 import "@/assets/scss/main.scss";
+
+axios.defaults.validateStatus = () => true;
 
 // Create the app
 const app = createApp(App);

--- a/web/src/types/uploads/UploadReport.ts
+++ b/web/src/types/uploads/UploadReport.ts
@@ -22,6 +22,7 @@ export type UploadReport = {
   isFromSharing: boolean;
 };
 
+
 export class Report {
   readonly fromSharing: boolean;
 
@@ -41,7 +42,7 @@ export class Report {
   }
 
   public hasFinalStatus() {
-    return this.status === "finished" || this.status === "error" || this.status === "failed";
+    return this.status !== "queued" && this.status !== "running";
   }
 
   static fromResponse(response: Record<string, any>, slug?: string, fromSharing?: boolean): Report {

--- a/web/src/types/uploads/UploadReportStatus.ts
+++ b/web/src/types/uploads/UploadReportStatus.ts
@@ -4,5 +4,5 @@ export type UploadReportStatus =
   | "failed"
   | "error"
   | "finished"
-  | "deleted"
+  | "purged"
   | "api_error";

--- a/web/src/views/upload/share.vue
+++ b/web/src/views/upload/share.vue
@@ -18,9 +18,9 @@ onMounted(async () => {
 
   try{
     // If the report reference does not exist, generate a new one.
-    if (!report) {
+    if (report === undefined) {
       // Fetch the report from the server
-      report = await reports.reloadReport(reportId);
+      report = await reports.addReportFromShared(reportId);
     }
 
     // Wait until status is final


### PR DESCRIPTION
When reports would be purged by the server (without the front-end knowing) it would cause the front end to keep fetching the reports indefinitely. This PR aims to fix that issue.

This is caused by the the Rails API trying to create an URL for non-existing files, throwing an error and returning an internal server error. The front-end then never gets to update the report status, causing it to keep periodically fetching the report.

This PR also removes migration code for the old local storage key.