### PR TITLE
Fix dolos-web Docker image not using the environment variables correctly

### DIFF
--- a/api/shell.nix
+++ b/api/shell.nix
@@ -2,7 +2,7 @@
 let
   dev = fetchTarball "https://github.com/numtide/devshell/archive/main.tar.gz";
   devshell = pkgs.devshell or (import dev { inherit system; });
-  ruby = pkgs.ruby_3_2;
+  ruby = pkgs.ruby_3_3;
 in
 devshell.mkShell {
   name = "Dolos API server";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
-
 name: dolos
-version: "3.9"
 services:
   db:
     image: mariadb:11

--- a/flake.lock
+++ b/flake.lock
@@ -2,19 +2,16 @@
   "nodes": {
     "devshell": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1713532798,
-        "narHash": "sha256-wtBhsdMJA3Wa32Wtm1eeo84GejtI43pMrFrmwLXrsEc=",
+        "lastModified": 1722113426,
+        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "12e914740a25ea1891ec619bb53cf5e6ca922e40",
+        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
         "type": "github"
       },
       "original": {
@@ -45,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716948383,
-        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "lastModified": 1725983898,
+        "narHash": "sha256-4b3A9zPpxAxLnkF9MawJNHDtOOl6ruL0r6Og1TEDGCE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "rev": "1355a0cbfeac61d785b7183c0caaec1f97361b43",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
       url = "github:numtide/devshell";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
       };
     };
   };

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.2.0-alpine3.19
+FROM node:22.8.0-alpine3.19
 
 WORKDIR /web/
 
@@ -10,10 +10,11 @@ RUN npm install && apk add --no-cache curl
 
 ENV VITE_HOST=0.0.0.0
 ENV VITE_PORT=8080
-ENV VITE_API_URL=http://localhost:3000
 ENV VITE_MODE=server
+ENV DEFAULT_VITE_API_URL=http://localhost:3000
 EXPOSE 8080/tcp
 
-RUN npm run build
+RUN VITE_API_URL="$DEFAULT_VITE_API_URL" npm run build
 
-CMD npm run preview -- --host "$VITE_HOST" --port "$VITE_PORT" --strictPort
+
+CMD (test "$VITE_API_URL" == "$DEFAULT_VITE_API_URL" || npm run build) && npm run preview -- --host "$VITE_HOST" --port "$VITE_PORT" --strictPort

--- a/web/src/views/analysis/overview.vue
+++ b/web/src/views/analysis/overview.vue
@@ -281,9 +281,7 @@ const similarities = computed(() =>
 
 // Average maximum similarity.
 const averageSimilarity = computed(() => {
-  const mean =
-    similarities.value.reduce((a, b) => a + b, 0) / similarities.value.length ??
-    0;
+  const mean = similarities.value.reduce((a, b) => a + b, 0) / similarities.value.length;
   return isNaN(mean) ? 0 : mean;
 });
 


### PR DESCRIPTION
dolos-web would be built using default variables (e.g. API URL `http://localhost:3000`) which would cause people's setup to fail (#1575). This PR fixes that issue by rebuilding the front-end if it differs from the default values.