### PR TITLE
Fix code highlighting bug

### DIFF
--- a/web/src/components/pair/PairCodeMatchEditor.vue
+++ b/web/src/components/pair/PairCodeMatchEditor.vue
@@ -43,7 +43,7 @@ const emit = defineEmits(["update:selectedMatch", "update:hoveringMatch"]);
 const colors = {
   match: "rgba(60, 115, 168, 0.2)",
   matchHovering: "rgba(60, 115, 168, 0.3)",
-  matchSelected: "rgba(26, 188, 156, 0.3)",
+  matchSelected: "rgba(26, 188, 156, 0.5)",
 };
 
 // File to display
@@ -180,6 +180,15 @@ const initializeSelections = (): void => {
   }
 };
 
+const areMatchesEqual = (match1: Fragment | null, match2: Fragment | null) => {
+  if (!match1 || !match2) return false;
+
+  return match1.left.startCol === match2.left.startCol &&
+         match1.left.endCol === match2.left.endCol &&
+         match1.right.startCol === match2.right.startCol &&
+         match1.right.endCol === match2.right.endCol;
+};
+
 // Initialize the editor decorations
 const initializeDecorations = (): void => {
   // Convert the selections into Monaco decorations.
@@ -189,12 +198,13 @@ const initializeDecorations = (): void => {
       const match = selection.match;
 
       let classname = "highlight-match";
-      if (match === selectedMatch.value) classname += " highlight-match--selected";
-      else if (match === hoveringMatch.value) classname += " highlight-match--hovering";
+      if (areMatchesEqual(match, selectedMatch?.value)) classname += " highlight-match--selected";
+      else if (areMatchesEqual(match, hoveringMatch?.value)) classname += " highlight-match--hovering";
+
 
       let color = colors.match;
-      if (match === selectedMatch.value) color = colors.matchSelected;
-      else if (match === hoveringMatch.value) color = colors.matchHovering;
+      if (areMatchesEqual(match, selectedMatch?.value)) color = colors.matchSelected;
+      else if (areMatchesEqual(match, hoveringMatch?.value)) color = colors.matchHovering;
 
       return {
         range: selection.range,


### PR DESCRIPTION
Currently in Dolos the feature to highlight which fragments are matched in the Matches view is broken. This is due to a small bug in the corresponding code which checks if the hovering/selected match is equal to the match whose decoration we are supposed to be changing. 

This PR changes how the equivalence is checked from the JS === to a small helper function called "areMatchesEqual" which checks that two matches have the same values. 

Feel free to suggest other solutions to this bug, but this seems to work quite well. I also changed the alpha value of the selected match to be less transparent.

Related issue: #1588