### PR TITLE
Add support for template files into CSV parsing

### DIFF
--- a/core/src/file/file.ts
+++ b/core/src/file/file.ts
@@ -11,6 +11,7 @@ export interface ExtraInfo {
   exerciseID: string;
   createdAt: Date;
   labels: string;
+  ignored: string;
 }
 
 /**

--- a/lib/src/lib/dataset.ts
+++ b/lib/src/lib/dataset.ts
@@ -1,0 +1,161 @@
+import { readFiles, readPath } from "./reader.js";
+
+import { ExtraInfo, File, Result } from "@dodona/dolos-core";
+import { csvParse, DSVRowString } from "d3-dsv";
+
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { spawnSync as spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+
+export class Dataset {
+  public nonIgnoredFiles: File[] = [];
+  public ignoredFile: File | undefined;
+  public nameCandidate: string | undefined;
+
+  constructor() {}
+
+  private async fromDirectory(dirPath: string): Promise<Result<File[]>> {
+    const dirs = [dirPath];
+    const files = [];
+
+    let i = 0;
+
+    while(i < dirs.length) {
+      for (const entry of await fs.readdir(dirs[i], { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          dirs.push(path.join(dirs[i], entry.name));
+        } else if (entry.isFile()) {
+          files.push(readPath(path.join(dirs[i], entry.name)));
+        }
+      }
+      i += 1;
+    }
+
+    return await Result.all(files);
+  }
+
+private async setIgnoredFile(resolvedFiles: File[], ignore?: string): Promise<File | undefined> {
+  const ignoredFiles = resolvedFiles.filter(file => file.extra?.ignored === "true");
+  if (ignoredFiles.length > 1) {
+    throw new Error("More than one file has the ignored field set to true. Only one template/boilerplate code file is allowed at this moment.");
+  }
+  else if (ignore) {
+      return (await readPath(ignore)).ok();
+  }
+  return ignoredFiles.length === 1 ? ignoredFiles[0] : undefined;
+}
+
+
+  private async fromZIP(zipPath: string, ignore?: string): Promise<Result<{ nonIgnoredFiles: File[], ignoredFile: File | undefined }>> {
+    const tmpDir = await fs.mkdtemp(path.join(tmpdir(), "dolos-unzip-"));
+    try {
+      const { status, error, stderr } = spawn("unzip", [zipPath, "-d", tmpDir]);
+      if (error) {
+        throw error;
+      } else if (status != 0) {
+        throw new Error(`Unzipping failed with exit status ${ status }, stderr: \n${stderr}`);
+      }
+      const infoPath = path.join(tmpDir, "info.csv");
+      if (await fs.access(infoPath, constants.R_OK).then(() => true).catch(() => false)) {
+        const { nonIgnoredFiles, ignoredFile } = (await this.fromCSV(infoPath, ignore)).ok();
+        if (nonIgnoredFiles) {
+          return Result.ok({nonIgnoredFiles, ignoredFile});
+        }
+        else {
+          throw new Error("Failed to process files");
+        }
+      } else {
+        const nonIgnoredFiles = (await this.fromDirectory(tmpDir)).ok();
+        const ignoredFile = undefined;
+        return Result.ok({nonIgnoredFiles, ignoredFile});
+      }
+    } finally {
+      await fs.rm(tmpDir, { recursive: true });
+    }
+  }
+
+
+  private async fromCSV(infoPath: string, ignore?: string): Promise<Result<{ nonIgnoredFiles: File[], ignoredFile: File | undefined }>> {
+    const dirname = path.dirname(infoPath);
+    try {
+      const files = csvParse((await fs.readFile(infoPath)).toString())
+        .map((row:  DSVRowString) => ({
+          filename: row.filename as string,
+          fullName: row.full_name as string,
+          id: row.id as string,
+          status: row.status as string,
+          submissionID: row.submission_id as string,
+          nameEN: row.name_en as string,
+          nameNL: row.name_nl as string,
+          exerciseID: row.exercise_id as string,
+          createdAt: new Date(row.created_at as string),
+          labels: row.label as string || row.labels as string,
+          ignored: row.ignored as string
+        }))
+        .map((row: ExtraInfo) => readPath(path.join(dirname, row.filename), row));
+        const resolvedFiles = await Result.all(files);
+        const ignoredFile = await this.setIgnoredFile(resolvedFiles.ok(), ignore);
+        const nonIgnoredFiles = resolvedFiles.ok().filter(file => file.extra?.ignored !== "true");
+      return Result.ok({nonIgnoredFiles, ignoredFile});
+    } catch(e) {
+      throw new Error("The given '.csv'-file could not be opened");
+    }
+  }
+
+
+  public async createNameCandidate(paths: string[]): Promise<string> {
+    let nameCandidate = "undefined";
+    if (paths.length === 1) {
+      if (paths[0].toLowerCase().endsWith(".zip")) {
+        nameCandidate = path.basename(paths[0], ".zip");
+      } else if (paths[0].toLowerCase().endsWith(".csv")) {
+        if (paths[0].endsWith("info.csv")) {
+          nameCandidate = path.dirname(paths[0]).split(path.sep).pop() || "undefined";
+        }
+      }
+    }
+    else if (paths.length === 2) {
+      nameCandidate = path.basename(paths[0]) + " & " + path.basename(paths[1]);
+    }
+    return nameCandidate;
+  }
+
+  public async prepareDataset(paths: string[], ignore?: string): Promise<Dataset> {
+    let files = null;
+    let filesFromZIP = null;
+    let filesFromCSV = null;
+  
+    if (paths.length == 1) {
+      const inputFile = paths[0];
+      if (inputFile.toLowerCase().endsWith(".zip")) {
+        filesFromZIP = this.fromZIP(inputFile, ignore);
+      } else if (inputFile.toLowerCase().endsWith(".csv")) {
+        filesFromCSV = this.fromCSV(inputFile, ignore);
+      } else {
+        throw new Error("You gave one input file, but it is not a CSV file or a ZIP archive.");
+      }
+    } else {
+      files = readFiles(paths);
+    }
+
+    this.nameCandidate = await this.createNameCandidate(paths);
+    
+    if (files) {
+      this.nonIgnoredFiles = (await files).ok();
+      this.ignoredFile = await this.setIgnoredFile(this.nonIgnoredFiles, ignore); 
+    } else if (filesFromZIP) {
+      const { nonIgnoredFiles, ignoredFile } = (await filesFromZIP).ok();
+      this.nonIgnoredFiles = nonIgnoredFiles;
+      this.ignoredFile = ignoredFile;
+    } else if (filesFromCSV) {
+      const { nonIgnoredFiles, ignoredFile } = (await filesFromCSV).ok();
+      this.nonIgnoredFiles = nonIgnoredFiles;
+      this.ignoredFile = ignoredFile;
+    } else {
+      throw new Error("No files to analyze");
+    }
+    return this;
+  }
+}

--- a/lib/src/lib/dataset.ts
+++ b/lib/src/lib/dataset.ts
@@ -10,13 +10,13 @@ import { spawnSync as spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 
 export class Dataset {
-  public nonIgnoredFiles: File[] = [];
-  public ignoredFile: File | undefined;
-  public nameCandidate: string | undefined;
+  constructor(
+      public name: string,
+      public files: File[],
+      public ignore?: File) {
+  }
 
-  constructor() {}
-
-  private async fromDirectory(dirPath: string): Promise<Result<File[]>> {
+  private static async fromDirectory(dirPath: string): Promise<Result<File[]>> {
     const dirs = [dirPath];
     const files = [];
 
@@ -36,7 +36,7 @@ export class Dataset {
     return await Result.all(files);
   }
 
-  private async setIgnoredFile(resolvedFiles: File[], ignore?: string): Promise<File | undefined> {
+  private static async setIgnoredFile(resolvedFiles: File[], ignore?: string): Promise<File | undefined> {
     const ignoredFiles = resolvedFiles.filter(file => file.extra?.ignored === "true");
     if (ignoredFiles.length > 1) {
       throw new Error(
@@ -51,10 +51,10 @@ export class Dataset {
   }
 
 
-  private async fromZIP(
+  private static async fromZIP(
     zipPath: string,
     ignore?: string
-  ): Promise<Result<{ nonIgnoredFiles: File[], ignoredFile: File | undefined }>> {
+  ): Promise<Dataset> {
     const tmpDir = await fs.mkdtemp(path.join(tmpdir(), "dolos-unzip-"));
     try {
       const { status, error, stderr } = spawn("unzip", [zipPath, "-d", tmpDir]);
@@ -65,17 +65,19 @@ export class Dataset {
       }
       const infoPath = path.join(tmpDir, "info.csv");
       if (await fs.access(infoPath, constants.R_OK).then(() => true).catch(() => false)) {
-        const { nonIgnoredFiles, ignoredFile } = (await this.fromCSV(infoPath, ignore)).ok();
-        if (nonIgnoredFiles) {
-          return Result.ok({ nonIgnoredFiles, ignoredFile });
+        const dataset = await Dataset.fromCSV(infoPath, ignore);
+        if (dataset) {
+          dataset.name = path.basename(zipPath, ".zip");
+          return dataset;
         }
         else {
           throw new Error("Failed to process files");
         }
       } else {
-        const nonIgnoredFiles = (await this.fromDirectory(tmpDir)).ok();
+        const files = (await this.fromDirectory(tmpDir)).ok();
         const ignoredFile = undefined;
-        return Result.ok({ nonIgnoredFiles, ignoredFile });
+        const nameCandidate = path.basename(zipPath, ".zip");
+        return new Dataset(nameCandidate, files, ignoredFile);
       }
     } finally {
       await fs.rm(tmpDir, { recursive: true });
@@ -83,13 +85,13 @@ export class Dataset {
   }
 
 
-  private async fromCSV(
+  private static async fromCSV(
     infoPath: string,
     ignore?: string
-  ): Promise<Result<{ nonIgnoredFiles: File[], ignoredFile: File | undefined }>> {
+  ): Promise<Dataset> {
     const dirname = path.dirname(infoPath);
     try {
-      const files = csvParse((await fs.readFile(infoPath)).toString())
+      const csv_files = csvParse((await fs.readFile(infoPath)).toString())
         .map((row:  DSVRowString) => ({
           filename: row.filename as string,
           fullName: row.full_name as string,
@@ -104,67 +106,36 @@ export class Dataset {
           ignored: row.ignored as string
         }))
         .map((row: ExtraInfo) => readPath(path.join(dirname, row.filename), row));
-      const resolvedFiles = await Result.all(files);
+      const resolvedFiles = await Result.all(csv_files);
       const ignoredFile = await this.setIgnoredFile(resolvedFiles.ok(), ignore);
-      const nonIgnoredFiles = resolvedFiles.ok().filter(file => file.extra?.ignored !== "true");
-      return Result.ok({ nonIgnoredFiles, ignoredFile });
+      const files = resolvedFiles.ok().filter(file => file.extra?.ignored !== "true");
+      const nameCandidate = path.dirname(infoPath).split(path.sep).pop() || "undefined";
+      return new Dataset(nameCandidate, files, ignoredFile);
     } catch(e) {
       throw new Error("The given '.csv'-file could not be opened");
     }
   }
 
 
-  public async createNameCandidate(paths: string[]): Promise<string> {
+  public static async create(paths: string[], ignore?: string): Promise<Dataset> {
+    let resolvedIgnoredFile = null;
+    let resolvedFiles = null;
     let nameCandidate = "undefined";
-    if (paths.length === 1) {
-      if (paths[0].toLowerCase().endsWith(".zip")) {
-        nameCandidate = path.basename(paths[0], ".zip");
-      } else if (paths[0].toLowerCase().endsWith(".csv")) {
-        if (paths[0].endsWith("info.csv")) {
-          nameCandidate = path.dirname(paths[0]).split(path.sep).pop() || "undefined";
-        }
-      }
-    }
-    else if (paths.length === 2) {
-      nameCandidate = path.basename(paths[0]) + " & " + path.basename(paths[1]);
-    }
-    return nameCandidate;
-  }
 
-  public async prepareDataset(paths: string[], ignore?: string): Promise<Dataset> {
-    let files = null;
-    let filesFromZIP = null;
-    let filesFromCSV = null;
-  
     if (paths.length == 1) {
       const inputFile = paths[0];
       if (inputFile.toLowerCase().endsWith(".zip")) {
-        filesFromZIP = this.fromZIP(inputFile, ignore);
+        return Dataset.fromZIP(inputFile, ignore);
       } else if (inputFile.toLowerCase().endsWith(".csv")) {
-        filesFromCSV = this.fromCSV(inputFile, ignore);
+        return Dataset.fromCSV(inputFile, ignore);
       } else {
         throw new Error("You gave one input file, but it is not a CSV file or a ZIP archive.");
       }
     } else {
-      files = readFiles(paths);
+      resolvedFiles = (await readFiles(paths)).ok();
+      resolvedIgnoredFile = await this.setIgnoredFile(resolvedFiles, ignore);
+      nameCandidate = path.basename(paths[0]) + " & " + path.basename(paths[1]);
+      return new Dataset(nameCandidate, resolvedFiles, resolvedIgnoredFile);
     }
-
-    this.nameCandidate = await this.createNameCandidate(paths);
-    
-    if (files) {
-      this.nonIgnoredFiles = (await files).ok();
-      this.ignoredFile = await this.setIgnoredFile(this.nonIgnoredFiles, ignore); 
-    } else if (filesFromZIP) {
-      const { nonIgnoredFiles, ignoredFile } = (await filesFromZIP).ok();
-      this.nonIgnoredFiles = nonIgnoredFiles;
-      this.ignoredFile = ignoredFile;
-    } else if (filesFromCSV) {
-      const { nonIgnoredFiles, ignoredFile } = (await filesFromCSV).ok();
-      this.nonIgnoredFiles = nonIgnoredFiles;
-      this.ignoredFile = ignoredFile;
-    } else {
-      throw new Error("No files to analyze");
-    }
-    return this;
   }
 }

--- a/lib/src/lib/dolos.ts
+++ b/lib/src/lib/dolos.ts
@@ -21,8 +21,8 @@ export class Dolos {
   }
 
   public async analyzePaths(paths: string[], ignore?: string): Promise<Report> {
-    const dataset = await (new Dataset()).prepareDataset(paths, ignore);
-    return this.analyze(dataset.nonIgnoredFiles, dataset.nameCandidate, dataset.ignoredFile);
+    const dataset = await Dataset.create(paths, ignore);
+    return this.analyze(dataset.files, dataset.name, dataset.ignore);
   }
 
   public async analyze(

--- a/lib/src/lib/dolos.ts
+++ b/lib/src/lib/dolos.ts
@@ -2,16 +2,9 @@ import { Report } from "./report.js";
 import { CustomOptions, Options } from "./options.js";
 import { Tokenizer } from "./tokenizer/tokenizer.js";
 import { Language, LanguagePicker } from "./language.js";
-import { readFiles, readPath } from "./reader.js";
+import { Dataset } from "./dataset.js";
 
-import { FingerprintIndex, ExtraInfo, File, Result } from "@dodona/dolos-core";
-import { csvParse, DSVRowString } from "d3-dsv";
-
-import { constants } from "node:fs";
-import fs from "node:fs/promises";
-import path from "node:path";
-import { spawnSync as spawn } from "node:child_process";
-import { tmpdir } from "node:os";
+import { FingerprintIndex, File } from "@dodona/dolos-core";
 
 export class Dolos {
   readonly options: Options;
@@ -27,121 +20,9 @@ export class Dolos {
     this.options = new Options(customOptions);
   }
 
-  private async fromDirectory(dirPath: string): Promise<Result<File[]>> {
-    const dirs = [dirPath];
-    const files = [];
-
-    let i = 0;
-
-    while(i < dirs.length) {
-      for (const entry of await fs.readdir(dirs[i], { withFileTypes: true })) {
-        if (entry.isDirectory()) {
-          dirs.push(path.join(dirs[i], entry.name));
-        } else if (entry.isFile()) {
-          files.push(readPath(path.join(dirs[i], entry.name)));
-        }
-      }
-      i += 1;
-    }
-
-    return await Result.all(files);
-  }
-
-  private async fromZIP(zipPath: string): Promise<Result<File[]>> {
-    const tmpDir = await fs.mkdtemp(path.join(tmpdir(), "dolos-unzip-"));
-    try {
-      const { status, error, stderr } = spawn("unzip", [zipPath, "-d", tmpDir]);
-      if (error) {
-        throw error;
-      } else if (status != 0) {
-        throw new Error(`Unzipping failed with exit status ${ status }, stderr: \n${stderr}`);
-      }
-      const infoPath = path.join(tmpDir, "info.csv");
-      if (await fs.access(infoPath, constants.R_OK).then(() => true).catch(() => false)) {
-        const { nonIgnoredFiles } = (await this.fromCSV(infoPath)).ok();
-        if (nonIgnoredFiles) {
-          return Result.ok(nonIgnoredFiles);
-        }
-        else {
-          throw new Error("Failed to process files");
-        }
-      } else {
-        return await this.fromDirectory(tmpDir);
-      }
-    } finally {
-      await fs.rm(tmpDir, { recursive: true });
-    }
-  }
-
-  private async fromCSV(infoPath: string): Promise<Result<{ nonIgnoredFiles: File[], ignoredFile: File | undefined }>> {
-    const dirname = path.dirname(infoPath);
-    try {
-      const files = csvParse((await fs.readFile(infoPath)).toString())
-        .map((row:  DSVRowString) => ({
-          filename: row.filename as string,
-          fullName: row.full_name as string,
-          id: row.id as string,
-          status: row.status as string,
-          submissionID: row.submission_id as string,
-          nameEN: row.name_en as string,
-          nameNL: row.name_nl as string,
-          exerciseID: row.exercise_id as string,
-          createdAt: new Date(row.created_at as string),
-          labels: row.label as string || row.labels as string,
-          ignored: row.ignored as string
-        }))
-        .map((row: ExtraInfo) => readPath(path.join(dirname, row.filename), row));
-        const resolvedFiles = await Result.all(files);
-        const ignoredFiles = resolvedFiles.ok().filter(file => file.extra?.ignored === "true");
-        if (ignoredFiles.length > 1) {
-          throw new Error("More than one file has the ignored field set to true.");
-        }
-        const ignoredFile = ignoredFiles.length === 1 ? ignoredFiles[0] : undefined;
-        const nonIgnoredFiles = resolvedFiles.ok().filter(file => file.extra?.ignored !== "true");
-      return Result.ok({nonIgnoredFiles, ignoredFile});
-    } catch(e) {
-      throw new Error("The given '.csv'-file could not be opened");
-    }
-  }
-
-
   public async analyzePaths(paths: string[], ignore?: string): Promise<Report> {
-    let files = null;
-    let files_from_csv = null;
-    let ignoredFile = undefined;
-    let nameCandidate = undefined;
-    if(paths.length == 1) {
-      const inputFile = paths[0];
-      if(inputFile.toLowerCase().endsWith(".zip")) {
-        files = this.fromZIP(inputFile);
-        nameCandidate = path.basename(inputFile, ".zip");
-      } else if(inputFile.toLowerCase().endsWith(".csv")) {
-        files_from_csv = this.fromCSV(inputFile);
-        if (inputFile.endsWith("info.csv")) {
-          nameCandidate = path.dirname(inputFile).split(path.sep).pop();
-        }
-      } else {
-        throw new Error("You gave one input file, but is not a CSV file or a ZIP archive.");
-      }
-    } else {
-      files = readFiles(paths);
-      if (paths.length === 2) {
-        nameCandidate = path.basename(paths[0]) + " & " + path.basename(paths[1]);
-      }
-    }
-      if (files) {
-        if (ignore) {
-          ignoredFile = (await readPath(ignore)).ok();
-        }
-        return this.analyze((await files).ok(), nameCandidate, ignoredFile);
-      }
-      else if (files_from_csv) {
-        const { nonIgnoredFiles, ignoredFile } = (await files_from_csv).ok();
-        return this.analyze(nonIgnoredFiles, nameCandidate, ignoredFile);
-      }
-      else {
-        throw new Error("No files to analyze");
-      }
+    const dataset = await (new Dataset()).prepareDataset(paths, ignore);
+    return this.analyze(dataset.nonIgnoredFiles, dataset.nameCandidate, dataset.ignoredFile);
   }
 
   public async analyze(

--- a/lib/src/test/dolos.test.ts
+++ b/lib/src/test/dolos.test.ts
@@ -234,6 +234,33 @@ test("should read CSV-files", async t => {
   t.true(pairs[0].similarity > 0.75);
 });
 
+test("should read CSV-files with template code", async t => {
+  const dolos = new Dolos();
+
+  const report = await dolos.analyzePaths(["./src/test/fixtures/javascript/info_with_template.csv"]);
+
+  const files = report.files;
+  t.is(5, files.length);
+
+  const boilerplate = files[0];
+  const unique = files[1];
+  const alternative = files[2];
+  const similar  = files[3];
+
+  // Boilerplate copy should not have a match
+  t.is(0, report.getPair(boilerplate, unique).similarity);
+  t.is(0, report.getPair(boilerplate, alternative).similarity);
+  t.is(0, report.getPair(boilerplate, similar).similarity);
+
+
+  const unique_alternative = report.getPair(unique, alternative);
+  const unique_similar = report.getPair(unique, similar);
+  const alternative_similar = report.getPair(alternative, similar);
+  t.true(unique_alternative.similarity < alternative_similar.similarity, "Pairs with unique should be less similar");
+  t.true(unique_similar.similarity < alternative_similar.similarity, "Pairs with unique should be less similar");
+  t.true(alternative_similar.similarity > 0.5, "Pairs with similar code should have a similarity above 50%");
+});
+
 test("should read ZIP-files with info.csv", async t => {
   const dolos = new Dolos();
 

--- a/lib/src/test/fixtures/javascript/info_with_template.csv
+++ b/lib/src/test/fixtures/javascript/info_with_template.csv
@@ -1,0 +1,7 @@
+filename,id,labels,created_at,ignored
+boilerplate.js,1,original,2019-07-23 17:12:33 +0200,true
+boilerplate_copy.js,1,original,2019-07-23 17:12:33 +0200
+implementation-unique.js,2,copy,2019-07-25 11:02:57 +0200
+implementation-alternative.js,3,copy,2019-07-25 14:43:20 +0200
+implementation-alternative-similar.js,4,copy,2019-07-27 19:22:39 +0200
+boilerplate_copy.js,5,template,2019-07-27 19:22:39 +0200


### PR DESCRIPTION
This PR makes modifications to allow for template files to be included through the info.csv metadata. Only one template file is allowed and if multiple are occurring, then an error is thrown. Basically the CSV reader now takes into account a row called 'ignored', which is then designated as the template/boilerplate code. Feel free to give feedback on this solution, and I will be happy to improve it.

Also a test was added for this feature.