### PR TITLE
Improve tokenizer performance

### DIFF
--- a/lib/src/lib/tokenizer/charTokenizer.ts
+++ b/lib/src/lib/tokenizer/charTokenizer.ts
@@ -2,21 +2,17 @@ import { Region } from "@dodona/dolos-core";
 import { Token, Tokenizer } from "./tokenizer.js";
 
 export class CharTokenizer extends Tokenizer {
-  /**
-   * Runs the parser on a given string. Returns an async iterator returning
-   * tuples containing the stringified version of the token and the
-   * corresponding position.
-   *
-   * @param text The text string to parse
-   */
-  public *generateTokens(text: string): IterableIterator<Token> {
-    for (const [lineNumber, line] of text.split("\n").entries())
-      yield* line
-        .split("")
-        .map((char, col) => this.newToken(char, new Region(lineNumber, col, lineNumber, col + 1)));
-  }
 
-  generateTokensNew(text: string): Token[] {
-    return [...this.generateTokens(text)];
+  generateTokens(text: string): Token[] {
+    const tokens = [];
+    for (const [lineNumber, line] of text.split("\n").entries()) {
+      tokens.push(
+        line
+          .split("")
+          .map((char, col) => this.newToken(char, new Region(lineNumber, col, lineNumber, col + 1)))
+      );
+    }
+
+    return tokens.flat();
   }
 }

--- a/lib/src/lib/tokenizer/charTokenizer.ts
+++ b/lib/src/lib/tokenizer/charTokenizer.ts
@@ -15,4 +15,8 @@ export class CharTokenizer extends Tokenizer {
         .split("")
         .map((char, col) => this.newToken(char, new Region(lineNumber, col, lineNumber, col + 1)));
   }
+
+  generateTokensNew(text: string): Token[] {
+    return [...this.generateTokens(text)];
+  }
 }

--- a/lib/src/lib/tokenizer/charTokenizer.ts
+++ b/lib/src/lib/tokenizer/charTokenizer.ts
@@ -4,15 +4,14 @@ import { Token, Tokenizer } from "./tokenizer.js";
 export class CharTokenizer extends Tokenizer {
 
   generateTokens(text: string): Token[] {
-    const tokens = [];
+    const tokens: Token[] = [];
     for (const [lineNumber, line] of text.split("\n").entries()) {
-      tokens.push(
-        line
-          .split("")
-          .map((char, col) => this.newToken(char, new Region(lineNumber, col, lineNumber, col + 1)))
-      );
+      for (let col = 0; col < line.length; col++) {
+        tokens.push(this.newToken(line[col], new Region(lineNumber, col, lineNumber, col + 1)));
+
+      }
     }
 
-    return tokens.flat();
+    return tokens;
   }
 }

--- a/lib/src/lib/tokenizer/codeTokenizer.ts
+++ b/lib/src/lib/tokenizer/codeTokenizer.ts
@@ -1,5 +1,5 @@
 import { default as Parser, SyntaxNode } from "tree-sitter";
-import { Region, assert } from "@dodona/dolos-core";
+import { assert, Region } from "@dodona/dolos-core";
 import { Token, Tokenizer } from "./tokenizer.js";
 import { ProgrammingLanguage } from "../language.js";
 
@@ -51,7 +51,8 @@ export class CodeTokenizer extends Tokenizer {
       node.endPosition.column
     );
 
-    const location = Region.firstDiff(fullSpan, this.getChildrenRegions(node));
+    const childrenRegions = this.getChildrenRegions(node);
+    const location = Region.firstDiff(fullSpan,childrenRegions);
     assert(location !== null, "There should be at least one diff'ed region");
 
     yield this.newToken("(", location);
@@ -83,5 +84,41 @@ export class CodeTokenizer extends Tokenizer {
         );
 
     return node.children.map(getChildrenRegion).flat();
+  }
+
+  generateTokensNew(text: string): Token[] {
+    const tree = this.parser.parse(text, undefined, { bufferSize: Math.max(32 * 1024, text.length * 2) });
+    return this.tokenizeNodeNew(tree.rootNode)[0];
+  }
+  
+  private tokenizeNodeNew(node: SyntaxNode): [Token[], Region[]]{
+    const fullSpan = new Region(
+      node.startPosition.row,
+      node.startPosition.column,
+      node.endPosition.row,
+      node.endPosition.column
+    );
+    
+    const allNodes: Token[] = [];
+    const allRegions: Region[] = [];
+    const childrenNodes: Token[] = [];
+
+    for (const child of node.namedChildren) {
+      const [tokens, regions] = this.tokenizeNodeNew(child);
+      childrenNodes.push(...tokens);
+      allRegions.push(...regions);
+    }
+
+    const location = Region.firstDiff(fullSpan, allRegions);
+    assert(location !== null, "There should be at least one diff'ed region");
+
+    allNodes.push(this.newToken("(", location));
+    allNodes.push(this.newToken(node.type, location));
+    allNodes.push(...childrenNodes);
+    allNodes.push(this.newToken(")", location));
+
+    allRegions.push(fullSpan);
+
+    return [allNodes, allRegions];
   }
 }

--- a/lib/src/lib/tokenizer/codeTokenizer.ts
+++ b/lib/src/lib/tokenizer/codeTokenizer.ts
@@ -43,6 +43,16 @@ export class CodeTokenizer extends Tokenizer {
     return this.tokenizeNode(tree.rootNode)[0];
   }
 
+  /**
+   * Tokenizes the given node and its child nodes. It will create a list of Tokens
+   * containing the stringified version of the token and the corresponding position.
+   *
+   * @param node The node (and child nodes) that will be tokenized.
+   *
+   * @returns A tuple `(Tokens, (startRow, startCol))`, where `Tokens`
+   * is the current list of tokens, and `(startRow, startCol)` represents
+   * the starting position of the given tokenized node.
+   */
   private tokenizeNode(node: SyntaxNode): [Token[], [number,number]]{
     const location = new Region(
       node.startPosition.row,
@@ -58,6 +68,7 @@ export class CodeTokenizer extends Tokenizer {
 
       const [childNodes, [childStartRow, childStartCol]] = this.tokenizeNode(child);
 
+      // If the code is already captured in one of the children, the region of the current node can be shortened.
       if ((childStartRow < location.endRow) || (childStartRow === location.endRow && childStartCol < location.endCol)) {
         location.endRow = childStartRow;
         location.endCol = childStartCol;
@@ -68,6 +79,7 @@ export class CodeTokenizer extends Tokenizer {
 
     allNodes.push(this.newToken(")", location));
 
+    // Also return the startRow and startCol, this can be used by the parent node.
     return [allNodes, [location.startRow, location.startCol]];
   }
 }

--- a/lib/src/lib/tokenizer/tokenizer.ts
+++ b/lib/src/lib/tokenizer/tokenizer.ts
@@ -20,6 +20,8 @@ export abstract class Tokenizer {
    */
   public abstract generateTokens(text: string): IterableIterator<Token>;
 
+  public abstract generateTokensNew(text:string): Token[];
+
   /**
    * Returns a tokenized version of the given file.
    *
@@ -49,7 +51,7 @@ export abstract class Tokenizer {
   public tokenizeWithMapping(text: string): [string[], Region[]] {
     const resultTokens: Array<string> = [];
     const positionMapping: Array<Region> = [];
-    for (const { token, location } of this.generateTokens(text)) {
+    for (const { token, location } of this.generateTokensNew(text)) {
       resultTokens.push(token);
       positionMapping.push(location);
     }

--- a/lib/src/lib/tokenizer/tokenizer.ts
+++ b/lib/src/lib/tokenizer/tokenizer.ts
@@ -12,15 +12,13 @@ export abstract class Tokenizer {
 
 
   /**
-   * Runs the tokenizer on a given Buffer. Returns an async iterator returning
-   * tuples containing the stringified version of the token and the
+   * Runs the parser on a given string. Returns a list of Tokens
+   * containing the stringified version of the token and the
    * corresponding position.
    *
    * @param text The text string to parse
    */
-  public abstract generateTokens(text: string): IterableIterator<Token>;
-
-  public abstract generateTokensNew(text:string): Token[];
+  public abstract generateTokens(text:string): Token[];
 
   /**
    * Returns a tokenized version of the given file.
@@ -38,7 +36,7 @@ export abstract class Tokenizer {
    * @param text The buffer to stringify
    */
   public tokenize(text: string): string {
-    return Array.of(...this.generateTokens(text)).join();
+    return Array.of(this.generateTokens(text)).join();
   }
 
   /**
@@ -51,10 +49,10 @@ export abstract class Tokenizer {
   public tokenizeWithMapping(text: string): [string[], Region[]] {
     const resultTokens: Array<string> = [];
     const positionMapping: Array<Region> = [];
-    for (const { token, location } of this.generateTokensNew(text)) {
+    this.generateTokens(text).forEach(({ location, token }) => {
       resultTokens.push(token);
       positionMapping.push(location);
-    }
+    });
     return [resultTokens, positionMapping];
   }
 

--- a/lib/src/lib/tokenizer/tokenizer.ts
+++ b/lib/src/lib/tokenizer/tokenizer.ts
@@ -36,7 +36,7 @@ export abstract class Tokenizer {
    * @param text The buffer to stringify
    */
   public tokenize(text: string): string {
-    return Array.of(this.generateTokens(text)).join();
+    return this.generateTokens(text).join();
   }
 
   /**
@@ -49,10 +49,10 @@ export abstract class Tokenizer {
   public tokenizeWithMapping(text: string): [string[], Region[]] {
     const resultTokens: Array<string> = [];
     const positionMapping: Array<Region> = [];
-    this.generateTokens(text).forEach(({ location, token }) => {
+    for (const { token, location } of this.generateTokens(text)) {
       resultTokens.push(token);
       positionMapping.push(location);
-    });
+    }
     return [resultTokens, positionMapping];
   }
 

--- a/lib/src/test/dolos.test.ts
+++ b/lib/src/test/dolos.test.ts
@@ -30,8 +30,8 @@ test("equal content should be a full match", async t => {
   t.is(fragments.length, 1);
   const match = fragments[0];
 
-  t.deepEqual(new Region(2, 2, 9, 37), match.leftSelection);
-  t.deepEqual(new Region(2, 2, 9, 37), match.rightSelection);
+  t.deepEqual(new Region(2, 2, 9, 32), match.leftSelection);
+  t.deepEqual(new Region(2, 2, 9, 32), match.rightSelection);
 
   t.is(0, match.leftkgrams.from);
   t.is(0, match.rightkgrams.from);
@@ -64,7 +64,7 @@ test("renamed variables should be a full match", async t => {
   const wereld = () => "wereld";
 
   function halloWereld() {
-    console.log(halo() + " " + wereld())
+    console.log(hallo() + " " + wereld())
   }
   `;
 
@@ -82,8 +82,8 @@ test("renamed variables should be a full match", async t => {
   t.is(fragments.length, 1);
   const match = fragments[0];
 
-  t.deepEqual(new Region(2, 2, 9, 37), match.leftSelection);
-  t.deepEqual(new Region(2, 2, 9, 37), match.rightSelection);
+  t.deepEqual(new Region(2, 2, 9, 32), match.leftSelection);
+  t.deepEqual(new Region(2, 2, 9, 32), match.rightSelection);
 
   t.is(0, match.leftkgrams.from);
   t.is(0, match.rightkgrams.from);

--- a/lib/src/test/tokenizer.test.ts
+++ b/lib/src/test/tokenizer.test.ts
@@ -96,7 +96,7 @@ test("should be able to correctly tokenize a variable", async t => {
   const { tokens, mapping } = tokenizer.tokenizeFile(file);
   t.is(tokens.join(""), "(program(variable_declaration(variable_declarator(identifier)(number))))");
   t.is(mapping.length, 15);
-  t.deepEqual(mapping, [
+  t.deepEqual([
     new Region(0, 0, 0, 0),
     new Region(0, 0, 0, 0),
     new Region(0, 0, 0, 4),
@@ -112,7 +112,7 @@ test("should be able to correctly tokenize a variable", async t => {
     new Region(0, 4, 0, 12),
     new Region(0, 0, 0, 4),
     new Region(0, 0, 0, 0)
-  ]);
+  ], mapping);
 });
 
 test("should be able to correctly tokenize a loop", async t => {
@@ -125,7 +125,7 @@ test("should be able to correctly tokenize a loop", async t => {
       "(while_statement(parenthesized_expression(binary_expression(identifier)(number)))" +
       "(statement_block(expression_statement(augmented_assignment_expression(identifier)(number))))))");
   t.is(mapping.length, 45);
-  t.deepEqual(mapping,     [
+  t.deepEqual( [
     new Region (0,0,0,0),
     new Region (0,0,0,0),
     new Region (0,0,0,4),
@@ -171,6 +171,6 @@ test("should be able to correctly tokenize a loop", async t => {
     new Region (1,15,2,2),
     new Region (1,0,1,6),
     new Region (0,0,0,0),
-  ]
+  ],mapping
   );
 });

--- a/lib/src/test/tokenizer.test.ts
+++ b/lib/src/test/tokenizer.test.ts
@@ -24,6 +24,27 @@ const languageFiles = {
   "verilog": "../samples/verilog/module.v"
 } as {[key: string]: string};
 
+const tokenLength = {
+  "../samples/bash/caesar.sh": 1185,
+  "../samples/c/caesar.c": 582,
+  "../samples/c-sharp/Caesar.cs": 606,
+  "../samples/char/caesar.txt": 3700,
+  "../samples/cpp/caesar.cpp": 801,
+  "../samples/elm/Caesar.elm": 753,
+  "../samples/groovy/caesar.groovy": 282,
+  "../samples/java/Caesar.java": 522,
+  "../samples/javascript/sample.js": 861,
+  "../samples/python/caesar.py": 309,
+  "../samples/php/caesar.php": 411,
+  "../samples/modelica/sample.mo": 7542,
+  "../samples/r/caesar.R": 594,
+  "../samples/scala/Caesar.scala": 366,
+  "../samples/sql/sample.sql": 543,
+  "../samples/tsx/sample.tsx": 1659,
+  "../samples/typescript/caesar.ts": 378,
+  "../samples/verilog/module.v": 2484
+} as {[key: string]: number};
+
 for (const [languageName, languageFile] of Object.entries(languageFiles)) {
   test(`LanguagePicker can find ${languageName} correctly by name`, async t => {
     const language = await new LanguagePicker().findLanguage(languageName);
@@ -49,6 +70,7 @@ for (const [languageName, languageFile] of Object.entries(languageFiles)) {
     const { tokens } = tokenizer.tokenizeFile(file);
     t.truthy(tokens);
     t.snapshot(tokens, "stable tokenization");
+    t.is(tokens.length, tokenLength[languageFile]);
   });
 }
 
@@ -101,15 +123,15 @@ test("should be able to correctly tokenize a variable", async t => {
     new Region(0, 0, 0, 0),
     new Region(0, 0, 0, 4),
     new Region(0, 0, 0, 4),
-    new Region(0, 4, 0, 12),
-    new Region(0, 4, 0, 12),
+    new Region(0, 4, 0, 4),
+    new Region(0, 4, 0, 4),
     new Region(0, 4, 0, 8),
     new Region(0, 4, 0, 8),
     new Region(0, 4, 0, 8),
     new Region(0, 11, 0, 12),
     new Region(0, 11, 0, 12),
     new Region(0, 11, 0, 12),
-    new Region(0, 4, 0, 12),
+    new Region(0, 4, 0, 4),
     new Region(0, 0, 0, 4),
     new Region(0, 0, 0, 0)
   ], mapping);
@@ -130,43 +152,43 @@ test("should be able to correctly tokenize a loop", async t => {
     new Region (0,0,0,0),
     new Region (0,0,0,4),
     new Region (0,0,0,4),
-    new Region (0,4,0,9),
-    new Region (0,4,0,9),
+    new Region (0,4,0,4),
+    new Region (0,4,0,4),
     new Region (0,4,0,5),
     new Region (0,4,0,5),
     new Region (0,4,0,5),
     new Region (0,8,0,9),
     new Region (0,8,0,9),
     new Region (0,8,0,9),
-    new Region (0,4,0,9),
+    new Region (0,4,0,4),
     new Region (0,0,0,4),
     new Region (1,0,1,6),
     new Region (1,0,1,6),
     new Region (1,6,1,7),
     new Region (1,6,1,7),
-    new Region (1,7,1,13),
-    new Region (1,7,1,13),
+    new Region (1,7,1,7),
+    new Region (1,7,1,7),
     new Region (1,7,1,8),
     new Region (1,7,1,8),
     new Region (1,7,1,8),
     new Region (1,11,1,13),
     new Region (1,11,1,13),
     new Region (1,11,1,13),
-    new Region (1,7,1,13),
+    new Region (1,7,1,7),
     new Region (1,6,1,7),
     new Region (1,15,2,2),
     new Region (1,15,2,2),
     new Region (2,2,2,2),
     new Region (2,2,2,2),
-    new Region (2,2,2,8),
-    new Region (2,2,2,8),
+    new Region (2,2,2,2),
+    new Region (2,2,2,2),
     new Region (2,2,2,3),
     new Region (2,2,2,3),
     new Region (2,2,2,3),
     new Region (2,7,2,8),
     new Region (2,7,2,8),
     new Region (2,7,2,8),
-    new Region (2,2,2,8),
+    new Region (2,2,2,2),
     new Region (2,2,2,2),
     new Region (1,15,2,2),
     new Region (1,0,1,6),
@@ -174,3 +196,4 @@ test("should be able to correctly tokenize a loop", async t => {
   ],mapping
   );
 });
+


### PR DESCRIPTION
This PR improves the tokenizer performance by using a bottom-up algorithm to walk the syntax-tree to calculate the corresponding regions for each syntax node.

On our large benchmark dataset (1100 submissions), this change brings the time spent tokenizing the files down from 25 seconds to 2.5 seconds, **making this step 10 times faster**. As more than half of the total analysis was spent tokenizing, **Dolos is now more than twice as fast**.

**API change:** The `generateTokens` method of `Tokenizer` and its inheritors `CodeTokenizer` and `CharTokenizer` now returns an array `Token[]` instead of yielding `IterableIterator<Token>`. In most cases this will not break code using this method.