### PR TITLE
fixed a typo in the CLI help message

### DIFF
--- a/cli/src/cli/commands/run.ts
+++ b/cli/src/cli/commands/run.ts
@@ -28,7 +28,7 @@ export function runCommand(program: Command): Command {
     .option(
       "-l, --language <language>",
       Utils.indent(
-        "Programming language used in the submitted files. Or 'chars' to do " +
+        "Programming language used in the submitted files. Or 'char' to do " +
         "a character by character comparison. Detect automatically if not given.",
       ),
     )


### PR DESCRIPTION
The CLI help prompt used "chars" instead of "char" as the character-by-character comparison.