### PR TITLE
Uncomment pagination for clusters

### DIFF
--- a/web/src/components/clustering/ClustersTable.vue
+++ b/web/src/components/clustering/ClustersTable.vue
@@ -4,7 +4,7 @@
     :headers="headers"
     :items="items"
     :sort-by="sortBy"
-    :items-per-page="15"
+    :items-per-page="25"
     must-sort
     fixed-header
     @click:row="rowClicked"
@@ -28,11 +28,6 @@
           dim-below-cutoff
         />
       </span>
-    </template>
-
-    <!-- Temporary hack to hide pagination when disabled -->
-    <template v-if="!pagination" #bottom>
-      <div />
     </template>
   </v-data-table>
 </template>

--- a/web/src/components/clustering/ClustersTable.vue
+++ b/web/src/components/clustering/ClustersTable.vue
@@ -4,7 +4,7 @@
     :headers="headers"
     :items="items"
     :sort-by="sortBy"
-    :items-per-page="25"
+    :items-per-page="15"
     must-sort
     fixed-header
     @click:row="rowClicked"
@@ -29,6 +29,11 @@
         />
       </span>
     </template>
+
+    <!-- Hide the pagination buttons if pagination is disabled -->
+    <template v-if="!pagination" #bottom>
+      <div />
+    </template>
   </v-data-table>
 </template>
 
@@ -48,7 +53,7 @@ interface Props {
   pagination?: boolean;
 }
 
-const props = withDefaults(defineProps<Props>(), {});
+const props = withDefaults(defineProps<Props>(), { pagination: true });
 const router = useRouter();
 const pairStore = usePairStore();
 

--- a/web/src/views/analysis/overview.vue
+++ b/web/src/views/analysis/overview.vue
@@ -211,6 +211,7 @@
           <clusters-table
             :clusters="clustersOverview"
             :limit="10"
+            :pagination="false"
             concise
             disable-sorting
           />


### PR DESCRIPTION
Hello!

We noticed in our own usage of Dolos that the clusters are missing pagination. One of us found out that it is simply commented out in the code. She tried commenting it out and didn't notice that anything broke. I also tried it and it seemed ok. Was there some good reason for this page to not be paginated that we missed?

This PR basically just takes out those lines of code that disable pagination and adds a couple of rows to the page.

Feel free to give feedback if there is some issue with this

Thanks!