### PR TITLE
Improve web container build process

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,11 +2,14 @@ FROM node:22.10.0-alpine3.19
 
 WORKDIR /web/
 
+RUN apk add --no-cache curl
+
+ADD package.json /web/
+RUN npm install
+
 ADD public/ /web/public
 ADD src/ /web/src
-ADD index.html index.d.ts index.js package.json tsconfig.json tsconfig.node.json vite.config.ts /web/
-
-RUN npm install && apk add --no-cache curl
+ADD index.html index.d.ts index.js tsconfig.json tsconfig.node.json vite.config.ts /web/
 
 ENV VITE_HOST=0.0.0.0
 ENV VITE_PORT=8080


### PR DESCRIPTION
This MR restructures the Docker build process for the `web` image to improve caching and reusability of the layers:
- We move the installation of `curl` to the very front, so it is always reused. 
- We separately copy `package.json` and install the dependencies first, before copying all other files.

This way, when only some web code changes, it is no longer needed to install all dependencies again.