### PR TITLE
Improve Docker Compose setup flexibility through `.env` file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# The protocol on which Dolos will be accessed by the user - HTTP or HTTPS
+WEB_PROTOCOL=http
+
+# Database configuration
+DATABASE_ROOT_PASSWORD=root
+DATABASE_USER=dolos
+DATABASE_PASSWORD=dolos
+
+# Frontend configuration:
+### External refers to URLs as accessed in the user's browser
+### Internal refers to what the server should be listening for. These are
+###    useful when using a reverse proxy such as nginx.
+
+FRONTEND_EXTERNAL_HOST=localhost # Domain name as entered in the browser
+FRONTEND_EXTERNAL_PORT=8080      # Port on which the service is available
+#FRONTEND_EXTERNAL_PATH=         # Uncomment this line to provide a subpath on which Dolos is hosted (e.g. /dolos)
+
+#FRONTEND_INTERNAL_HOST=         # Defaults to 0.0.0.0, listening to all clients
+#FRONTEND_INTERNAL_PORT=         # Defaults to FRONTEND_EXTERNAL_PORT
+
+# API configuration:
+### External refers to URLs as accessed in the user's browser
+### Internal refers to what the server should be listening for. These are
+###     useful when using a reverse proxy such as nginx.
+
+API_EXTERNAL_HOST=localhost   # Domain name as entered in the browser
+API_EXTERNAL_PORT=3000        # Port on which the API service is made available
+#API_EXTERNAL_PATH=           # Uncomment this line to provide a subpath on which the API is hosted (e.g. /api)
+
+#API_INTERNAL_HOST=           # Defaults to 0.0.0.0, listening to all clients
+#API_INTERNAL_PORT=           # Defaults to API_EXTERNAL_PORT

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 !docs/yarn.lock
 **/yarn.lock
 *.csv
+.env
 *.log
 *.tgz
 *.tsbuildinfo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,22 +5,30 @@ services:
     volumes:
       - dolos-db-data:/var/lib/mysql
     environment:
-      MARIADB_ROOT_PASSWORD: dolos
+      MARIADB_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD:?}
+      MARIADB_DATABASE: dolos
+      MARIADB_USER: ${DATABASE_USER:?}
+      MARIADB_PASSWORD: ${DATABASE_PASSWORD:?}
     networks:
       - dolos
     healthcheck:
       start_period: 2s
       interval: 5s
       test: healthcheck.sh --su-mysql --connect --innodb_initialized
+    restart: always
+
   web:
     image: ghcr.io/dodona-edu/dolos-web
     # build: ./web/
     ports:
-      - "8080:8080"
+      # This renders to "host:port:8080", so traffic from the provided hosts on the specified
+      # port is available to port 8080 inside the container. By default, this will be
+      # 0.0.0.0:8080:8080.
+      - ${FRONTEND_INTERNAL_HOST:-0.0.0.0}:${FRONTEND_INTERNAL_PORT:-${FRONTEND_EXTERNAL_PORT:?}}:8080
     environment:
       VITE_HOST: 0.0.0.0
       VITE_PORT: 8080
-      VITE_API_URL: http://localhost:3000
+      VITE_API_URL: ${WEB_PROTOCOL:?}://${API_EXTERNAL_HOST:?}:${API_EXTERNAL_PORT:?}/${API_EXTERNAL_PATH:-}
       VITE_MODE: server
     depends_on:
       - api
@@ -30,6 +38,8 @@ services:
       start_period: 2s
       interval: 5s
       test: curl --fail http://localhost:8080 || exit 1
+    restart: always
+
   api:
     image: ghcr.io/dodona-edu/dolos-api
     # build: ./api/
@@ -38,12 +48,15 @@ services:
       - dolos-api-storage:/dolos/storage
       - /tmp:/tmp
     ports:
-      - "3000:3000"
+      # This renders to "host:port:3000", so traffic from the provided hosts on the specified
+      # port is available to port 3000 inside the container. By default, this will be
+      # 0.0.0.0:3000:3000.
+      - ${API_INTERNAL_HOST:-0.0.0.0}:${API_INTERNAL_PORT:-${API_EXTERNAL_PORT:?}}:3000
     environment:
-      DOLOS_API_FRONT_END_URL: http://localhost:8080
-      DOLOS_API_URL: http://localhost:3000
-      DOLOS_API_DATABASE_USERNAME: root
-      DOLOS_API_DATABASE_PASSWORD: dolos
+      DOLOS_API_FRONT_END_URL: ${WEB_PROTOCOL:?}://${FRONTEND_EXTERNAL_HOST:?}:${FRONTEND_EXTERNAL_PORT:?}/${FRONTEND_EXTERNAL_PATH:-}
+      DOLOS_API_URL: ${WEB_PROTOCOL:?}://${API_EXTERNAL_HOST:?}:${API_EXTERNAL_PORT:?}/${API_EXTERNAL_PATH:-}
+      DOLOS_API_DATABASE_USERNAME: ${DATABASE_USER:?}
+      DOLOS_API_DATABASE_PASSWORD: ${DATABASE_PASSWORD:?}
       DOLOS_API_DATABASE_HOST: db
       RAILS_ENV: production
       RAILS_LOG_TO_STDOUT: true
@@ -56,7 +69,12 @@ services:
     healthcheck:
       start_period: 2s
       interval: 10s
-      test: curl --fail "$$DOLOS_API_URL/up" || exit 1
+      # This health check "emulates" a browser request to API_EXTERNAL_*, while actually just
+      # querying localhost. This way, we overcome the strict host checking done by rails, which
+      # is based on the DOLOS_API_URL variable.
+      test: 'curl --fail --header "Host: ${API_EXTERNAL_HOST:-localhost}:${API_EXTERNAL_PORT:?}" --header "X-Forwarded-Proto: ${WEB_PROTOCOL:-http}" "localhost:3000/up" || exit 1'
+    restart: always
+
   worker:
     image: ghcr.io/dodona-edu/dolos-api
     # build: ./api/
@@ -66,8 +84,8 @@ services:
       - /tmp:/tmp
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      DOLOS_API_DATABASE_USERNAME: root
-      DOLOS_API_DATABASE_PASSWORD: dolos
+      DOLOS_API_DATABASE_USERNAME: ${DATABASE_USER:?}
+      DOLOS_API_DATABASE_PASSWORD: ${DATABASE_PASSWORD:?}
       DOLOS_API_DATABASE_HOST: db
       RAILS_ENV: production
       SECRET_KEY_BASE_DUMMY: true
@@ -80,6 +98,8 @@ services:
       start_period: 2s
       interval: 5s
       test: ruby -e true || exit 1
+    restart: always
+
 volumes:
   dolos-db-data:
   dolos-api-storage:

--- a/docs/docs/hosting-dolos.md
+++ b/docs/docs/hosting-dolos.md
@@ -3,9 +3,9 @@
 If you do not want to use our free to use instance ([dolos.ugent.be/server](https://dolos.ugent.be/server)),
 it is also possible to host your own instance.
 
-## Local hosting using docker-compose
+## Local hosting using Docker Compose
 
-These instructions are for **local** hosting only. The section [external hosting](#external-hosting-without-docker-compose) explains how you create a public instance of Dolos.
+These instructions are for **local** hosting only. The section [external hosting](#external-hosting) explains how you create a public instance of Dolos.
 
 [Docker](https://www.docker.com/) is a containerization technology that allows you to run our service without the hassle of installing the different dependencies and services yourself.
 
@@ -18,12 +18,13 @@ Run Dolos on your own system using these instructions:
     git clone https://github.com/dodona-edu/dolos.git
     cd dolos/
   ```
-3. Run `docker-compose pull` in this directory to pull and fetch all needed container images.
+3. Run `cp .env.example .env` to create a copy of the template environment settings.
+3. Run `docker compose pull` in this directory to pull and fetch all needed container images.
 4. Run `docker pull ghcr.io/dodona-edu/dolos-cli:latest` to ensure the container running the Dolos CLI is present and up-to-date.
-5. Run `docker-compose up` to start the services.
+5. Run `docker compose up` to start the services.
 
 You can now visit the web app running locally on <http://localhost:8080>.
-The API is available on <http://localhost:3000>.
+The API is available on <http://localhost:3000>. By changing the entries in the `.env` file, it is possible to change the ports on which Dolos is hosted - these are the settings `FRONTEND_EXTERNAL_PORT` and `API_EXTERNAL_PORT`. After such changes, make sure to run `docker compose up` again to apply.
 
 ::: warning
 
@@ -34,9 +35,9 @@ This grants the web app full control over your docker instance.
 
 :::
 
-## External hosting without docker-compose
+## External hosting
 
-To host your own public instance of Dolos, you will need some extra security precautions that are not included in the `docker-compose.yml` configuration:
+To host your own public instance of Dolos, you will need some extra security precautions that are not included in the default `docker-compose.yml` configuration:
 - **configure a domain name** and subdomain or path for the API
 - **configure HTTPS**
 - **configure serving static files** for the front-end Web UI
@@ -44,6 +45,17 @@ To host your own public instance of Dolos, you will need some extra security pre
 This is typically handled by using a reverse proxy like Nginx, Apache, Traefik, ... 
 
 As this configuration is highly dependent on your situation, we recommend [contacting us](/about/contact) describing what you want to achieve.
+
+### Running Docker Compose behind a reverse proxy
+
+The provided Docker Compose configuration provides some basic provisions to run Dolos behind a reverse proxy, which should be set up separately. After setting up the reverse proxy, you should customise the `.env` settings. For these instructions, we assume we want to host Dolos on `https://foo.example.com/` and the API on `https://foo.example.com/api`.
+
+- `WEB_PROTOCOL` should be set to `https` (assuming the reverse proxy has this set up)
+- The three `DATABASE_*` fields should be changed to more secure values
+- The `FRONTEND_EXTERNAL_*` fields should correspond to the public endpoint of your Dolos instance. In this case, `_HOST` would be `foo.example.com`, `_PORT` would be `443` (public HTTPS), and `_PATH` can be left empty.
+- `FRONTEND_INTERNAL_HOST` should be the IP address where your reverse proxy is located, typically `127.0.0.1`. This prevents external users from bypassing the revervse proxy: only the proxy can contact Dolos.
+- `FRONTEND_INTERNAL_PORT` should be set to the port that your reverse proxy will be using to contact Dolos. This is different from the external port.
+- The `API_*` fields should be set up in the same way as the `FRONTEND_` fields before, but now you should provide `_PATH` as `/api`.
 
 ### Configurable environment variables
 


### PR DESCRIPTION
This MR proposes some improvements to the preprovided Docker Compose setup. In particular:
- Easily enable user customisation through an `.env` file
- Allow customisation of database credentials
- Restructure ports and container environment variables to now use a single set of hosting parameters, that allows for both local and public hosting behind a reverse proxy.
- Include relevant documentation

My main motivation of including these changes is to simplify hosting Dolos behind a reverse proxy. I spent quite some time getting everything to work properly in a "production"-ready setup, due to the complex interplay between container-specific variables and ports. This of course does not include the configuration of a reverse proxy itself, which should still be done by the user.