### PR TITLE
Only calculate common prefix up until path separators

### DIFF
--- a/web/src/api/stores/file.store.ts
+++ b/web/src/api/stores/file.store.ts
@@ -216,10 +216,8 @@ export const useFileStore = defineStore("file", () => {
     }
 
     // Find the common path in the files.
-    const commonPath = commonFilenamePrefix(
-      Object.values(files),
-      (f) => f.path
-    );
+    const commonPath = commonFilenamePrefix(Object.values(files),);
+
     const commonPathLength = commonPath.length;
     for (const file of Object.values(files)) {
       file.shortPath = file.path.substring(commonPathLength);

--- a/web/src/api/utils/file.ts
+++ b/web/src/api/utils/file.ts
@@ -13,19 +13,37 @@ export function fileToTokenizedFile(file: File): TokenizedFile {
 /**
  * Common filename prefix for a given list of files
  * @param files Files
- * @param getPath Function to extract the path from the file
  * @returns Common prefix for all files.
  */
-export function commonFilenamePrefix(files: File[], getPath: (f: File) => string): string {
+export function commonFilenamePrefix(files: File[]): string {
   if (files.length <= 1) return "";
-
-  let index = 0;
-  while (
-    getPath(files[0])[index] &&
-    files.every((f) => getPath(f)[index] === getPath(files[0])[index])
-  ) {
-    index++;
+  //debugger;
+  const first = files[0].path;
+  // Find all possible locations with a path separator, sort them descending
+  const splitLocations = Array.from(first.matchAll(/[\\\/]/g)).map(r => r.index).sort().reverse();
+  /// If there are none, there is no desirable prefix
+  if (splitLocations.length == 0) {
+    return "";
+  }
+  let splitIndex = 0;
+  let prefixLength = splitLocations[splitIndex];
+  let i = 1;
+  while(i < files.length && prefixLength > 0) {
+    let j = 0;
+    while(j < prefixLength && first[j] == files[i].path[j]) {
+      j += 1;
+    }
+    while (prefixLength != undefined && j < prefixLength) {
+      splitIndex += 1;
+      prefixLength = splitLocations[splitIndex];
+    }
+    i += 1;
   }
 
-  return getPath(files[0]).substring(0, index) ?? "";
+  if (prefixLength == undefined || prefixLength == 0) {
+    return "";
+  } else {
+    return files[0].path.substring(0, prefixLength + 1);
+  }
+
 }

--- a/web/src/api/utils/file.ts
+++ b/web/src/api/utils/file.ts
@@ -20,7 +20,7 @@ export function commonFilenamePrefix(files: File[]): string {
   //debugger;
   const first = files[0].path;
   // Find all possible locations with a path separator, sort them descending
-  const splitLocations = Array.from(first.matchAll(/[\\\/]/g)).map(r => r.index).sort().reverse();
+  const splitLocations = Array.from(first.matchAll(/[\\/]/g)).map(r => r.index).sort().reverse();
   /// If there are none, there is no desirable prefix
   if (splitLocations.length == 0) {
     return "";

--- a/web/src/types/imports-components.d.ts
+++ b/web/src/types/imports-components.d.ts
@@ -33,7 +33,6 @@ declare module 'vue' {
     PairCodeMatch: typeof import('./../components/pair/PairCodeMatch.vue')['default']
     PairCodeMatchEditor: typeof import('./../components/pair/PairCodeMatchEditor.vue')['default']
     PairsTable: typeof import('./../components/pair/PairsTable.vue')['default']
-    QuestionnaireAlert: typeof import('./../components/QuestionnaireAlert.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SimilarityDisplay: typeof import('./../components/SimilarityDisplay.vue')['default']

--- a/web/src/views/analysis/overview.vue
+++ b/web/src/views/analysis/overview.vue
@@ -243,7 +243,6 @@ import {
   usePairStore,
   useMetadataStore,
 } from "@/api/stores";
-import router from "@/router";
 
 const apiStore = useApiStore();
 const fileStore = useFileStore();
@@ -323,9 +322,6 @@ const calculateBinColor = (x0: number, x1: number): string => {
   return x1 <= apiStore.cutoff ? "rgba(25, 118, 210, 0.25)" : "#1976D2";
 };
 
-const gotoSurvey = () => {
-  router.push("https://ugent.qualtrics.com/jfe/form/SV_6QpMmrEuuoGSMWW");
-}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
In the Web UI, we calculate the longest common prefix between all file paths, to avoid showing long redundant prefixes (e.g. `exercise/files/students/user1.py`,  `exercise/files/students/user2.py` are shown as `user1.py` and `user2.py`), but this would result in unexpected situations with for example `user10.py`  and `user1.py` which would be shown as `0.py` and `.py` (#1667).

This PR fixes that issue by only considering prefixes up until a path separator (`/` or `\`).

Fixes #1667 