### PR TITLE
Fix a sorting bug when calculating common prefix

### DIFF
--- a/web/src/api/utils/file.ts
+++ b/web/src/api/utils/file.ts
@@ -20,7 +20,7 @@ export function commonFilenamePrefix(files: File[]): string {
   //debugger;
   const first = files[0].path;
   // Find all possible locations with a path separator, sort them descending
-  const splitLocations = Array.from(first.matchAll(/[\\/]/g)).map(r => r.index).sort().reverse();
+  const splitLocations = Array.from(first.matchAll(/[\\/]/g)).map(r => r.index).sort((a, b) => b - a);
   /// If there are none, there is no desirable prefix
   if (splitLocations.length == 0) {
     return "";


### PR DESCRIPTION
Unfortunately JavaScript's `.sort()` sorts an array of numbers by converting the numbers to strings first :upside_down_face:,  which caused the new prefix determination from #1668 to determine incorrect prefixes in some cases.

This PR fixes that bug.

:facepalm: 