### PR TITLE
Support rootless Docker operation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,6 @@ API_EXTERNAL_PORT=3000        # Port on which the API service is made available
 
 #API_INTERNAL_HOST=           # Defaults to 0.0.0.0, listening to all clients
 #API_INTERNAL_PORT=           # Defaults to API_EXTERNAL_PORT
+
+# Worker configuration
+DOCKER_SOCKET=/var/run/docker.sock  # for a rootless Docker setup, use ${XDG_RUNTIME_DIR}/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     volumes:
       - dolos-api-storage:/dolos/storage
       - /tmp:/tmp
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_SOCKET}:/var/run/docker.sock
     environment:
       DOLOS_API_DATABASE_USERNAME: ${DATABASE_USER:?}
       DOLOS_API_DATABASE_PASSWORD: ${DATABASE_PASSWORD:?}


### PR DESCRIPTION
This MR adds support for rootless Docker (https://docs.docker.com/engine/security/rootless/) in the compose setup. The only difference is a custom Docker socket. By running rootless Docker, we prevent any vulnerability in the worker to be exploited to gain root access to the hosting machine.