### PR TITLE
Make dolos-parsers an optional dependency in lib

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@dodona/dolos-lib": "3.5.1",
+    "@dodona/dolos-parsers": "1.4.1",
     "@dodona/dolos-web": "2.9.3",
     "chalk": "^5.6.2",
     "cliui": "^9.0.1",

--- a/docs/docs/library.md
+++ b/docs/docs/library.md
@@ -13,6 +13,13 @@ Using `npm` to install the library, similar to [installing the CLI](/docs/instal
 npm install @dodona/dolos-lib
 ```
 
+By default, the library uses parsers provided by `@dodona/dolos-parsers`. You can install them with:
+```
+npm install @dodona/dolos-parsers
+```
+
+If a parser for a specific language is not available in `@dodona/dolos-parsers`, or if the package is not installed, the library will automatically fall back to using the corresponding `tree-sitter-<language>` package instead.
+
 ## Usage
 
 Take a look at our [example repository](https://github.com/rien/dolos-lib-example/blob/main/index.mjs)

--- a/lib/README.md
+++ b/lib/README.md
@@ -11,7 +11,7 @@ Visit [dolos.ugent.be](https://dolos.ugent.be) for more information.
 npm install @dodona/dolos-lib
 ```
 
-By default, the library uses parsers provided by `@dodona/dolos-parsers`. You can install them with:
+By default, the library tries to use the parsers provided by `@dodona/dolos-parsers`, which must be installed separately:
 ```
 npm install @dodona/dolos-parsers
 ```

--- a/lib/README.md
+++ b/lib/README.md
@@ -11,6 +11,13 @@ Visit [dolos.ugent.be](https://dolos.ugent.be) for more information.
 npm install @dodona/dolos-lib
 ```
 
+By default, the library uses parsers provided by `@dodona/dolos-parsers`. You can install them with:
+```
+npm install @dodona/dolos-parsers
+```
+
+If a parser for a specific language is not available in `@dodona/dolos-parsers`, or if the package is not installed, the library will automatically fall back to using the corresponding `tree-sitter-<language>` package instead.
+
 ### Node & Web environments
 
 **Required:** Node.js, Python 3 and a compiler (GCC)

--- a/lib/package.json
+++ b/lib/package.json
@@ -36,7 +36,6 @@
     "typescript": "6.0.3"
   },
   "dependencies": {
-    "@dodona/dolos-parsers": "1.4.1",
     "@dodona/dolos-core": "1.2.1",
     "d3-dsv": "^3.0.1",
     "tree-sitter": "^0.25.0"

--- a/lib/src/lib/language.ts
+++ b/lib/src/lib/language.ts
@@ -41,8 +41,12 @@ export class ProgrammingLanguage extends Language {
 
   public async loadLanguageModule(): Promise<TreeSitterLanguage> {
     if (this.languageModule === undefined) {
-      // @ts-ignore
-      this.languageModule = (await import("@dodona/dolos-parsers")).default[this.name];
+
+      try {
+        // @ts-ignore
+        this.languageModule = (await import("@dodona/dolos-parsers")).default[this.name];
+      } catch { /* empty */ }
+
       this.languageModule ||= (await import(`tree-sitter-${this.name}`)).default;
       if (this.languageModule === undefined) {
         throw new LanguageError(

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "license": "MIT",
       "dependencies": {
         "@dodona/dolos-lib": "3.5.1",
+        "@dodona/dolos-parsers": "1.4.1",
         "@dodona/dolos-web": "2.9.3",
         "chalk": "^5.6.2",
         "cliui": "^9.0.1",
@@ -89,7 +90,6 @@
       "license": "MIT",
       "dependencies": {
         "@dodona/dolos-core": "1.2.1",
-        "@dodona/dolos-parsers": "1.4.1",
         "d3-dsv": "^3.0.1",
         "tree-sitter": "^0.25.0"
       },


### PR DESCRIPTION
This PR removes `"@dodona/dolos-parsers": "1.4.1"` as dependency in `@dodona/dolos-lib`. The package can still be added by the user.

If a parser for a specific language is not available in `@dodona/dolos-parsers`, or if the package is not installed, the library will automatically fall back to using the corresponding `tree-sitter-<language>` package instead.